### PR TITLE
Deferred Blitting Emulation

### DIFF
--- a/src/blitter.cpp
+++ b/src/blitter.cpp
@@ -1,0 +1,127 @@
+#include "blitter.h"
+
+Uint32 get_pixel32( SDL_Surface *surface, int x, int y )
+{
+    //Convert the pixels to 32 bit
+    Uint32 *pixels = (Uint32 *)surface->pixels;
+    
+    //Get the requested pixel
+    return pixels[ ( y * surface->w ) + x ];
+}
+
+void put_pixel32( SDL_Surface *surface, int x, int y, Uint32 pixel )
+{
+    //Convert the pixels to 32 bit
+    Uint32 *pixels = (Uint32 *)surface->pixels;
+    
+    //Set the pixel
+    pixels[ ( y * surface->w ) + x ] = pixel;
+}
+
+void Blitter::SetParam(uint8_t address, uint8_t value) {
+    if((address % DMA_PARAMS_COUNT) == PARAM_TRIGGER) {
+        trigger = value & 1;
+        irq = false;
+        cpu_core->ClearIRQ();
+        if(trigger)
+            cpu_core->ScheduleIRQ(((params[Blitter::PARAM_HEIGHT] & 0x7F) * (params[Blitter::PARAM_WIDTH] & 0x7F)));
+    } else {
+        params[address % DMA_PARAMS_COUNT] = value;
+    }
+}
+
+#define ROWCOMPLETE (counterW == 0)
+#define XRELOAD (ROWCOMPLETE || init)
+#define COPYDONE (counterH == 0)
+#define XDIR (!!(params[PARAM_WIDTH] & 0x80))
+#define YDIR (!!(params[PARAM_HEIGHT] & 0x80))
+#define GCARRY(val) ((system_state->dma_control & DMA_GCARRY_BIT) ? val+1 : ((val & 0xF0) | ((val+1) & 0x0F)))
+
+void Blitter::CatchUp() {
+    uint64_t cycles = timekeeper->totalCyclesCount - last_updated_cycle;
+    last_updated_cycle = timekeeper->totalCyclesCount;
+    uint8_t colorbus;
+    while(cycles--) {
+        //PHASE 0
+            //Decrement Width Counter
+            //or Load if INIT
+            if(running) {
+                --counterW;
+            }
+
+            if(init) {
+                counterW = params[PARAM_WIDTH] & 0x7F;
+            }
+
+        //PHASE 1
+            //Decrement Height counter or load if INIT
+            //Increment counterVX, counterVY, GX, GY counters or load if INIT
+            if(running) {
+                ++counterVX;
+                counterGX = GCARRY(counterGX);
+                
+                if(ROWCOMPLETE) {
+                    ++counterVY;
+                    counterGY = GCARRY(counterGY);
+                    --counterH;
+                }
+            }
+
+            if(XRELOAD) {
+                counterVX = params[PARAM_VX];
+                counterGX = params[PARAM_GX];
+            }
+
+            if(init) {
+                counterVY = params[PARAM_VY];
+                counterGY = params[PARAM_GY];
+                counterH = params[PARAM_HEIGHT] & 0x7F;
+            }
+
+            if(COPYDONE) {
+                running = false;
+                irq = true;
+            }
+
+        //PHASE 2
+            //Reload width counter if it ran out
+            //Set RUNNING and reset TRIGGER if TRIGGER is set
+            running = running || init;
+            if(ROWCOMPLETE) counterW = params[PARAM_WIDTH] & 0x7F;
+
+        //PHASE 3
+            //Framebuffer write strobe
+            //Depending on spritecolor, transen, offscr_x/y, wrap_x/y
+            //Set INIT if TRIGGER, else reset INIT
+            init = trigger;
+            trigger = trigger && !init;
+
+            if(running) {
+                counterGX = XDIR ? ~counterGX : counterGX;
+                counterGY = YDIR ? ~counterGY : counterGY;
+                gram_mid_bits = (!!(counterGY & 0x80) * 2) + (!!(counterGX & 0x80) * 1);
+                if(system_state->dma_control & DMA_COLORFILL_ENABLE_BIT) {
+                    colorbus = ~(params[PARAM_COLOR]);
+                } else {
+                    uint32_t gOffset = ((system_state->banking & BANK_GRAM_MASK) << 16) + 
+                            (!!(counterGY & 0x80) << 15) +
+                            (!!(counterGX & 0x80) << 14);
+                    colorbus = system_state->gram[((counterGY & 0x7F) << 7) | (counterGX & 0x7F) | gOffset];
+                }
+                counterGX = XDIR ? ~counterGX : counterGX;
+                counterGY = YDIR ? ~counterGY : counterGY;
+
+                if(system_state->dma_control & DMA_COPY_ENABLE_BIT) {
+                    if(((system_state->dma_control & DMA_TRANSPARENCY_BIT) || (colorbus != 0))
+                        && !((counterVX & 0x80) && (system_state->banking & BANK_WRAPX_MASK))
+                        && !((counterVY & 0x80) && system_state->banking & BANK_WRAPY_MASK)) {
+                        int yShift = (system_state->banking & BANK_VRAM_MASK) ? 128 : 0;
+                        int vOffset = yShift << 7;
+                        system_state->vram[((counterVY & 0x7F) << 7) | (counterVX & 0x7F) | vOffset] = colorbus;
+                        put_pixel32(vram_surface, counterVX & 0x7F, (counterVY & 0x7F) + yShift, Palette::ConvertColor(vram_surface, colorbus));
+                    }
+                }
+            }
+
+    }
+}

--- a/src/blitter.h
+++ b/src/blitter.h
@@ -52,11 +52,12 @@ public:
     static const uint8_t PARAM_TRIGGER = 6;
     static const uint8_t PARAM_COLOR   = 7;
 
+    bool instant_mode = false;
     
     uint8_t gram_mid_bits;
 
     Blitter(mos6502*& cpu_core, Timekeeper* timekeeper, SystemState* system_state, SDL_Surface*& vram_surface) : cpu_core(cpu_core), timekeeper(timekeeper), system_state(system_state), vram_surface(vram_surface) {};
 
     void SetParam(uint8_t address, uint8_t value);
-    void CatchUp();
+    void CatchUp(uint64_t cycles=0);
 };

--- a/src/blitter.h
+++ b/src/blitter.h
@@ -1,0 +1,62 @@
+#include <cstdint>
+#include "timekeeper.h"
+#include "system_state.h"
+#include "SDL_inc.h"
+#include "mos6502/mos6502.h"
+#include "palette.h"
+
+#define DMA_PARAMS_COUNT 8
+
+#define DMA_COPY_ENABLE_BIT 1
+#define DMA_VID_OUT_PAGE_BIT 2
+#define DMA_VSYNC_NMI_BIT 4
+#define DMA_COLORFILL_ENABLE_BIT 8
+#define DMA_GCARRY_BIT 16
+#define DMA_CPU_TO_VRAM 32
+#define DMA_COPY_IRQ_BIT 64
+#define DMA_TRANSPARENCY_BIT 128
+
+Uint32 get_pixel32( SDL_Surface *surface, int x, int y );
+void put_pixel32( SDL_Surface *surface, int x, int y, Uint32 pixel );
+
+class Blitter {
+private:
+    mos6502*& cpu_core;
+    Timekeeper* timekeeper;
+    SystemState* system_state;
+    SDL_Surface*& vram_surface;
+
+    uint8_t counterVX;
+    uint8_t counterVY;
+    uint8_t counterGX;
+    uint8_t counterGY;
+    uint8_t counterW;
+    uint8_t counterH;
+
+    uint8_t params[DMA_PARAMS_COUNT];
+
+    bool trigger;
+    bool init;
+    bool irq;
+    bool running;
+
+    uint64_t last_updated_cycle = 0;
+
+public:
+    static const uint8_t PARAM_VX      = 0;
+    static const uint8_t PARAM_VY      = 1;
+    static const uint8_t PARAM_GX      = 2;
+    static const uint8_t PARAM_GY      = 3;
+    static const uint8_t PARAM_WIDTH   = 4;
+    static const uint8_t PARAM_HEIGHT  = 5;
+    static const uint8_t PARAM_TRIGGER = 6;
+    static const uint8_t PARAM_COLOR   = 7;
+
+    
+    uint8_t gram_mid_bits;
+
+    Blitter(mos6502*& cpu_core, Timekeeper* timekeeper, SystemState* system_state, SDL_Surface*& vram_surface) : cpu_core(cpu_core), timekeeper(timekeeper), system_state(system_state), vram_surface(vram_surface) {};
+
+    void SetParam(uint8_t address, uint8_t value);
+    void CatchUp();
+};

--- a/src/gte.cpp
+++ b/src/gte.cpp
@@ -585,6 +585,8 @@ void refreshScreen() {
 			if(ImGui::MenuItem("VRAM Viewer")) {
 				toggleVRAMWindow();
 			}
+			ImGui::Separator();
+			ImGui::MenuItem("Instant Blits", NULL, &(blitter->instant_mode));
 			ImGui::EndMenu();
 		}
 		ImGui::EndMainMenuBar();

--- a/src/gte.cpp
+++ b/src/gte.cpp
@@ -769,16 +769,6 @@ EM_BOOL mainloop(double time, void* userdata) {
 							ofstream dumpfile ("ram_debug.dat", ios::out | ios::binary);
 							dumpfile.write((char*) system_state.ram, RAMSIZE);
 							dumpfile.close();
-							loadedMemoryMap->forEach([](const Symbol& symbol) {
-								if(symbol.address < 0x2000) {
-									uint8_t value = MemoryReadResolve(symbol.address, false);
-									std::cout << symbol.name << "@" << std::hex << symbol.address << " = " << std::hex << static_cast<unsigned int>(value);
-									if(!system_state.ram_initialized[FULL_RAM_ADDRESS(symbol.address & 0x1FFF)]) {
-										std::cout << " (uninitialized)";
-									}
-									std::cout << std::endl;
-								}
-							});
 						}
 						break;
             		default:

--- a/src/palette.cpp
+++ b/src/palette.cpp
@@ -1,0 +1,11 @@
+#include "palette.h"
+#include "gametank_palette.h"
+
+Uint32 Palette::ConvertColor(SDL_Surface* target, uint8_t index) {
+    if(index == 0) return SDL_MapRGB(target->format, 0, 0, 0);
+	RGB_Color c = ((RGB_Color*)gt_palette_vals)[index];
+	Uint32 res = SDL_MapRGB(target->format, c.r, c.g, c.b);
+	if(res == SDL_MapRGB(target->format, 0, 0, 0))
+		return SDL_MapRGB(target->format, 1, 1, 1);
+	return res;
+}

--- a/src/palette.h
+++ b/src/palette.h
@@ -1,0 +1,11 @@
+#pragma once
+#include "SDL_inc.h"
+
+typedef struct RGB_Color {
+	uint8_t r, g, b;
+} RGB_Color;
+
+class Palette {
+public:
+    static Uint32 ConvertColor(SDL_Surface* target, uint8_t index);
+};

--- a/src/system_state.h
+++ b/src/system_state.h
@@ -8,6 +8,12 @@ const int FRAME_BUFFER_SIZE = 16384;
 #define VRAM_BUFFER_SIZE (FRAME_BUFFER_SIZE*2)
 #define GRAM_BUFFER_SIZE (FRAME_BUFFER_SIZE*32)
 
+#define BANK_GRAM_MASK  0b00000111
+#define BANK_VRAM_MASK  0b00001000
+#define BANK_WRAPX_MASK 0b00010000
+#define BANK_WRAPY_MASK 0b00100000
+#define BANK_RAM_MASK   0b11000000
+
 struct SystemState {
     uint8_t dma_control;
     uint8_t banking;
@@ -19,22 +25,6 @@ struct SystemState {
     uint8_t gram[GRAM_BUFFER_SIZE];
     
     uint8_t VIA_regs[16];
-};
-
-#define DMA_PARAMS_COUNT 8
-const uint8_t DMA_PARAM_VX      = 0;
-const uint8_t DMA_PARAM_VY      = 1;
-const uint8_t DMA_PARAM_GX      = 2;
-const uint8_t DMA_PARAM_GY      = 3;
-const uint8_t DMA_PARAM_WIDTH   = 4;
-const uint8_t DMA_PARAM_HEIGHT  = 5;
-const uint8_t DMA_PARAM_TRIGGER = 6;
-const uint8_t DMA_PARAM_COLOR   = 7;
-
-struct BlitterState
-{
-    uint8_t params[DMA_PARAMS_COUNT];
-    uint8_t gram_mid_bits;
 };
 
 struct CartridgeState


### PR DESCRIPTION
The real GameTank's blitter runs in parallel with CPU work and copies one pixel per cycle. The emulator has been operating under the assumption that the programmer would avoid interacting with its registers while it was running. However I'd like to allow programmers to experiment with this and see what techniques could be found by messing with the blitter mid-blit.

The new blitting emulation works incrementally, instead of happening all in one for-loop there's now a function that simulates the state of each counter and flipflop, and completes a given number of cycles. A timestamp is recorded whenever the blitter, video memory, or system registers are interacted with and the number of cycles since the previous interaction are processed.

The new method should accurately simulate what happens when the blitter registers are written to during a blit, as well as other behaviors such as disabling the blitter while it is running or changing framebuffer/sprite banks.

To ease the transition for any software currently under development an "Instant Blit" toggle is available in the menu bar that mimics the old behavior of the emulator.