### PR TITLE
Formatting in the debugger

### DIFF
--- a/src/devtools/disassembler.h
+++ b/src/devtools/disassembler.h
@@ -17,7 +17,7 @@ private:
         PR, ST, ZP, IX,
         ZX, ZY, ZI, IY
     };
-    static void FormatArgBytes(std::stringstream& ss, MemoryMap* mem_map, AddressMode mode, uint16_t argBytes);
+    static void FormatArgBytes(std::stringstream& ss, MemoryMap* mem_map, AddressMode mode, uint8_t argCount, uint16_t argBytes);
     static vector<string> opcodeNames;
     static AddressMode opcodeModes[256];
     static vector<string> lastDecode;


### PR DESCRIPTION
Adds specific bytes to debugger
Correctly pads values (e.g. 3 printed as 03)

I've added a argCount param to `FormatArgBytes` to be able to tell if the arg is one or two bytes.  I don't believe this is necessary as I believe the amount of bytes in the argument is determined by mode.  I'm not 100% sure which modes take how many bytes so I just left it like this for now

![image](https://github.com/clydeshaffer/GameTankEmulator/assets/4015408/607743ca-8b7e-4101-a1b4-3824cc8090f7)
