### PR TITLE
Use sdl2-config for build flags on linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,8 +70,8 @@ ifeq ($(OS), Windows_NT)
 	#LINKER_FLAGS specifies the libraries we're linking against
 	LINKER_FLAGS = -lmingw32 -lSDL2main -lSDL2 -Wl,-Bstatic -mwindows -lm -ldinput8 -ldxguid -ldxerr8 -luser32 -lgdi32 -lwinmm -limm32 -lcomdlg32 -lole32 -loleaut32 -lshell32 -lversion -luuid -static-libgcc -lsetupapi
 else
-	COMPILER_FLAGS = -g -I/usr/include/SDL2 $(IMGUI_INCLUDES)
-	LINKER_FLAGS = -lSDL2
+	COMPILER_FLAGS = -g `sdl2-config --cflags` $(IMGUI_INCLUDES)
+	LINKER_FLAGS = `sdl2-config --libs`
 endif
 ifeq ($(OS), wasm)
 	CC = emcc


### PR DESCRIPTION
I'm unsure if this will help anyone on normal repos, but it seems necessary for my Nixos setup.

Example `sdl2-config` output on Nixos:
```
$ sdl2-config --libs
-L/nix/store/rk2n6p9ihz60i0gn2wrv6cknmkrwvd5a-SDL2-2.30.2/lib -Wl,-rpath,/nix/store/rk2n6p9ihz60i0gn2wrv6cknmkrwvd5a-SDL2-2.30.2/lib -Wl,--enable-new-dtags -lSDL2
$ sdl2-config --cflags
-I/nix/store/p2yfmggqkrgbfai4hnmx789lvk7ip2kf-SDL2-2.30.2-dev/include/SDL2 -I/nix/store/p2yfmggqkrgbfai4hnmx789lvk7ip2kf-SDL2-2.30.2-dev/include/SDL2 -I/nix/store/p2yfmggqkrgbfai4hnmx789lvk7ip2kf-SDL2-2.30.2-dev/include/SDL2 -I/nix/store/p2yfmggqkrgbfai4hnmx789lvk7ip2kf-SDL2-2.30.2-dev/include/SDL2 -D_REENTRANT
```

Note that aside from all the `/nix` stuff the normal flags you'd expect (`-lSDL2`) are used