### PR TITLE
Allow passing xor file path as arg

### DIFF
--- a/src/emulator_config.cpp
+++ b/src/emulator_config.cpp
@@ -6,6 +6,7 @@ bool EmulatorConfig::noSound = false;
 bool EmulatorConfig::noJoystick = false;
 bool EmulatorConfig::noSave = false;
 Uint32 EmulatorConfig::defaultRendererFlags = SDL_RENDERER_ACCELERATED;
+char *EmulatorConfig::xorFile = NULL;
 
 void EmulatorConfig::parseArg(const char* arg) {
     if(strcmp(arg, "--nosound") == 0) {
@@ -22,6 +23,14 @@ void EmulatorConfig::parseArg(const char* arg) {
         noJoystick = true;
         return;
     }
+
+    const char *xorFilePrefix = "--xorFile=";
+    if(strncmp(arg, xorFilePrefix, strlen(xorFilePrefix)) == 0) {
+      // TODO memory allocated here, need to clean up
+      xorFile = strdup(arg + strlen(xorFilePrefix));
+      return;
+    }
+
 
     printf("Unrecognized option %s\n", arg);
 }

--- a/src/emulator_config.h
+++ b/src/emulator_config.h
@@ -8,4 +8,5 @@ public:
     static void parseArg(const char* arg);
     static Uint32 defaultRendererFlags;
     static bool noSave;
+    static char *xorFile;
 };

--- a/src/gte.cpp
+++ b/src/gte.cpp
@@ -572,8 +572,12 @@ extern "C" {
 #endif
 		nvramPath.replace_extension("sav");
 		nvramFileFullPath = nvramPath.string();
-		nvramPath.replace_extension("xor");
-		flashFileFullPath = nvramPath.string();
+		if (EmulatorConfig::xorFile != NULL) {
+		  flashFileFullPath = std::string(EmulatorConfig::xorFile);
+		} else {
+		    nvramPath.replace_extension("xor");
+		    flashFileFullPath = nvramPath.string();
+		}
 		nvramPath.replace_extension("gtrcfg");
 
 		gameconfig = new GameConfig(nvramPath.string().c_str());


### PR DESCRIPTION
Hi!  I'm making this change to make testing my game's save capabilities easier

Since I don't really write C++ I'm sure there's a ton of jank going on, definitely open to all critique!

A couple things:
- Idk if the terminology you'd prefer is "xor file" or "flash file"
- I'm not `free`ing the string I create with `strdup`.  I don't think this is too bad since it's only allocated at most once in the program's runtime, but I still don't like it lol.  I'm aware C++ has some sort of destructors that might be used to clean things like this up, but I'm not really sure about what their deal is.