### PR TITLE
Make the emulator build on MacOS too

### DIFF
--- a/src/SDL_inc.h
+++ b/src/SDL_inc.h
@@ -1,5 +1,7 @@
 #ifdef _WIN32
 #include <SDL.h>
+#elif __APPLE__
+#include "SDL.h"
 #else
 #include <SDL2/SDL.h>
 #endif


### PR DESCRIPTION
MacOS SDL (installed via homebrew) has a different include path for SDL2.

This ifdef gets it to build on my mac - and everything works out of the box.