### PR TITLE
Mute functionality

### DIFF
--- a/src/audio_coprocessor.cpp
+++ b/src/audio_coprocessor.cpp
@@ -45,6 +45,7 @@ void AudioCoprocessor::fill_audio(void *udata, uint8_t *stream, int len) {
             stream16[i] = state->dacReg;
             stream16[i] -= 128;
             stream16[i] *= state->volume;
+            stream16[i] *= state->isMuted ? 0 : 1;
         }
         state->irqCounter -= state->clksPerHostSample;
         if(state->irqCounter < 0) {
@@ -149,6 +150,7 @@ AudioCoprocessor::AudioCoprocessor() {
     state.cycles_per_sample = 1024;
     state.last_irq_cycles = 0;
     state.volume = 256;
+    state.isMuted = false;
     state.clkMult = 4;
 
 	for(int i = 0; i < AUDIO_RAM_SIZE; i ++) {

--- a/src/audio_coprocessor.h
+++ b/src/audio_coprocessor.h
@@ -25,6 +25,7 @@ typedef struct ACPState {
 	uint64_t cycle_counter;
 	SDL_AudioDeviceID device;
 	int volume;
+	bool isMuted;
 } ACPState;
 
 class AudioCoprocessor {

--- a/src/gte.cpp
+++ b/src/gte.cpp
@@ -840,6 +840,7 @@ void refreshScreen() {
 			}
 			ImGui::MenuItem("Toggle Instant Blits", NULL, &(blitter->instant_mode));
 			ImGui::SliderInt("Volume", &AudioCoprocessor::singleton_acp_state->volume, 0, 256);
+			ImGui::Checkbox("Mute", &AudioCoprocessor::singleton_acp_state->isMuted);
 			ImGui::EndMenu();
 		}
 		if(ImGui::BeginMenu("Tools")) {

--- a/src/gte.cpp
+++ b/src/gte.cpp
@@ -195,6 +195,7 @@ SDL_Renderer* mainRenderer = NULL;
 SDL_Texture* framebufferTexture = NULL;
 
 bool isFullScreen = false;
+bool isMuted = false;
 
 bool profiler_open = false;
 bool buffers_open = false;
@@ -764,6 +765,10 @@ void toggleFullScreen() {
 	timekeeper.scaling_increment = INITIAL_SCALING_INCREMENT;
 }
 
+void toggleMute() {
+	isMuted = !isMuted;
+}
+
 typedef struct HotkeyAssignment {
 	void (*func)();
 	SDL_Keycode  key;
@@ -771,6 +776,7 @@ typedef struct HotkeyAssignment {
 
 HotkeyAssignment hotkeys[] = {
 	{&toggleFullScreen, SDLK_F11},
+	{&toggleMute, SDLK_m},
 #ifndef WASM_BUILD
 	{&doRamDump, SDLK_F6},
 	{&toggleSteppingWindow, SDLK_F7},
@@ -979,7 +985,7 @@ EM_BOOL mainloop(double time, void* userdata) {
 		refreshScreen();
 		SDL_UpdateWindowSurface(mainWindow);
 
-		if(EmulatorConfig::noSound) {
+		if(EmulatorConfig::noSound || isMuted) {
 			AudioCoprocessor::fill_audio(AudioCoprocessor::singleton_acp_state, NULL, intended_cycles / AudioCoprocessor::singleton_acp_state->cycles_per_sample);
 		}
 

--- a/src/gte.cpp
+++ b/src/gte.cpp
@@ -195,7 +195,6 @@ SDL_Renderer* mainRenderer = NULL;
 SDL_Texture* framebufferTexture = NULL;
 
 bool isFullScreen = false;
-bool isMuted = false;
 
 bool profiler_open = false;
 bool buffers_open = false;
@@ -766,7 +765,7 @@ void toggleFullScreen() {
 }
 
 void toggleMute() {
-	isMuted = !isMuted;
+	AudioCoprocessor::singleton_acp_state->isMuted = !AudioCoprocessor::singleton_acp_state->isMuted;
 }
 
 typedef struct HotkeyAssignment {
@@ -985,7 +984,7 @@ EM_BOOL mainloop(double time, void* userdata) {
 		refreshScreen();
 		SDL_UpdateWindowSurface(mainWindow);
 
-		if(EmulatorConfig::noSound || isMuted) {
+		if(EmulatorConfig::noSound) {
 			AudioCoprocessor::fill_audio(AudioCoprocessor::singleton_acp_state, NULL, intended_cycles / AudioCoprocessor::singleton_acp_state->cycles_per_sample);
 		}
 

--- a/src/joystick_config.cpp
+++ b/src/joystick_config.cpp
@@ -100,10 +100,6 @@ void load_joystick_defaults(std::vector<InputBinding> &bindings) {
 	b.button = GameTankButtons::P1_A;
 	bindings.push_back(b);
 
-	b.host_input.key = SDLK_b;
-	b.button = GameTankButtons::P1_A;
-	bindings.push_back(b);
-
 	b.host_input.key = SDLK_j;
 	b.button = GameTankButtons::P1_A;
 	bindings.push_back(b);
@@ -112,19 +108,11 @@ void load_joystick_defaults(std::vector<InputBinding> &bindings) {
 	b.button = GameTankButtons::P1_B;
 	bindings.push_back(b);
 
-	b.host_input.key = SDLK_n;
-	b.button = GameTankButtons::P1_B;
-	bindings.push_back(b);
-
 	b.host_input.key = SDLK_k;
 	b.button = GameTankButtons::P1_B;
 	bindings.push_back(b);
 
 	b.host_input.key = SDLK_c;
-	b.button = GameTankButtons::P1_C;
-	bindings.push_back(b);
-
-	b.host_input.key = SDLK_m;
 	b.button = GameTankButtons::P1_C;
 	bindings.push_back(b);
 


### PR DESCRIPTION
Pressing the M key toggles mute (mute disabled by default obv).  To make room for this, the third set of p1 controls (bnm -> abc) have been removed.

I also added a checkbox for this to the settings pane (see image)

![image](https://github.com/user-attachments/assets/25f25033-79c5-4452-a1ec-e4863a0acf5a)
