### PR TITLE
Add algorithm header to build on arch

### DIFF
--- a/src/gte.cpp
+++ b/src/gte.cpp
@@ -9,6 +9,7 @@
 #include <filesystem>
 #include <vector>
 #include <thread>
+#include <algorithm>
 #ifdef WASM_BUILD
 #include "emscripten.h"
 #include <emscripten/html5.h>


### PR DESCRIPTION
Adding this because `remove_if` and `for_each` weren't recognized without the `algorithm` header on arch using gcc `14.1.1`