### PR TITLE
Display values of vram pixels under mouse

### DIFF
--- a/src/devtools/vram_window.cpp
+++ b/src/devtools/vram_window.cpp
@@ -8,7 +8,8 @@ VRAMWindow::VRAMWindow(
     SDL_Surface* vram, SDL_Surface* gram, 
     SystemState* system, mos6502* cpu, 
     CartridgeState* cartridge) : BaseWindow(BUFFERS_PREVIEW_WIDTH, BUFFERS_PREVIEW_HEIGHT) {
-    
+
+    SDL_SetWindowTitle(window, "VRAM Viewer");
     surface = SDL_GetWindowSurface(window);
     SDL_SetColorKey(surface, SDL_FALSE, 0);
 
@@ -17,37 +18,54 @@ VRAMWindow::VRAMWindow(
     system_state = system;
     cpu_core = cpu;
     cartridge_state = cartridge;
-
 }
 
 void VRAMWindow::Draw() {
     SDL_Rect src, dest;
-	dest.x = 0;
-	dest.y = 0;
-	dest.w = 128;
-	dest.h = 256;
-	src.x = 0;
-	src.y = 0;
-	src.w = 128;
-	src.h = 256;
-	SDL_BlitSurface(vRAM_Surface, &src, surface, &dest);
-	src.h = 512;
-	dest.h = 512;
-	for(int i = 0; i < 8; i++) {
-		dest.x = (i+1) * 128;
-		src.y = i * 512;
-		SDL_BlitSurface(gRAM_Surface, &src, surface, &dest);
-	}
 
-	char buf[128];
-	sprintf(buf, "DMA:\n%x\nBANK:\n%x\nPC:\n%x\nSTATUS:\n%x\nWAIT:%d\nHIBITS:%d",
-        system_state->dma_control, system_state->banking, cpu_core->pc, cpu_core->status,
-        cpu_core->waiting, cartridge_state->bank_mask);
-	dest.x = 0;
-	dest.y = 256;
-	dest.w = 128;
-	dest.h = 512-128;
-	drawText(surface, &dest, buf);
+    // Clear the surface before re-rendering
+    dest.x = 0;
+    dest.y = 0;
+    dest.w = 128*9;
+    dest.h = 512;
+    SDL_FillRect(surface, &dest, 0);
+
+    dest.x = 0;
+    dest.y = 0;
+    dest.w = 128;
+    dest.h = 256;
+    src.x = 0;
+    src.y = 0;
+    src.w = 128;
+    src.h = 256;
+    SDL_BlitSurface(vRAM_Surface, &src, surface, &dest);
+    src.h = 512;
+    dest.h = 512;
+    for(int i = 0; i < 8; i++) {
+    dest.x = (i+1) * 128;
+    src.y = i * 512;
+    SDL_BlitSurface(gRAM_Surface, &src, surface, &dest);
+    }
+
+    char buf[128];
+
+    int charsWritten = sprintf(
+	buf,
+	"DMA:\n%x\nBANK:\n%x\nPC:\n%x\nSTATUS:\n%x\nWAIT:%d\nHIBITS:%d\n\n",
+	system_state->dma_control,
+	system_state->banking,
+	cpu_core->pc,
+	cpu_core->status,
+	cpu_core->waiting,
+	cartridge_state->bank_mask
+    );
+
+    WriteDataUnderMouse(buf + charsWritten, 128 - charsWritten);
+    dest.x = 0;
+    dest.y = 256;
+    dest.w = 128;
+    dest.h = 512-128;
+    drawText(surface, &dest, buf);
 
     SDL_UpdateWindowSurface(window);
 }
@@ -60,5 +78,42 @@ void VRAMWindow::HandleEvent(SDL_Event& e) {
                 open = false;
             }
         }
+    }
+}
+
+void VRAMWindow::WriteDataUnderMouse(char *buf, int bufSize) {
+    int x, y;
+    SDL_Window *focusedWindow;
+
+    focusedWindow = SDL_GetMouseFocus();
+
+    if (focusedWindow != window) {
+	// The user is not currently hovering over the VRAM Viewer
+	// There is no data under their mouse to be written
+	return;
+    }
+
+    SDL_GetMouseState(&x, &y);
+
+    // Which region of the VRAM viewer does the user's mouse lie in?
+    if (x < 128 && y >= 256) {
+	// The user is hovering over the area where debug information is printed
+	// There are no relevant pixels to describe here
+	return;
+    }
+
+    if (x < 128) {
+	// The user is hovering over VRAM
+	const int vram_start = 0;
+	int addr = vram_start + (128*y) + x;
+
+	snprintf(buf, bufSize - 1, "VRAM\nADDR: 0x%X\nVAL: 0x%02X", addr, system_state->vram[addr]);
+    } else {
+	// The user is hovering over GRAM
+	x -= 128;
+	const int gram_start = 0;
+	int addr = gram_start + ((x >> 7) * 128 * 512) + (128*y) + (x % 128);
+
+	snprintf(buf, bufSize - 1, "GRAM\nADDR: 0x%X\nVAL: 0x%02X", addr, system_state->gram[addr]);
     }
 }

--- a/src/devtools/vram_window.cpp
+++ b/src/devtools/vram_window.cpp
@@ -109,16 +109,47 @@ void VRAMWindow::WriteDataUnderMouse(char *buf, int bufSize) {
 
     if (x < 128) {
 	// The user is hovering over VRAM
-	const int vram_start = 0;
-	int addr = vram_start + (128*y) + x;
+	int vram_start = 0x4000;
+	int hovered_pixel = (128*y) + x;
+	int addr = vram_start + (128*(y % 128)) + x;
 
-	snprintf(buf, bufSize - 1, "VRAM\nADDR: 0x%X\nVAL: 0x%02X", addr, system_state->vram[addr]);
+	int framebuffer = y >> 7;
+
+	snprintf(
+	  buf,
+	  bufSize - 1,
+	  "VRAM\nFRAMEBUFFER: %d\nADDR: 0x%X\nVAL: 0x%02X",
+	  framebuffer,
+	  addr,
+	  system_state->vram[hovered_pixel]
+	);
     } else {
 	// The user is hovering over GRAM
+        // Correct for the fact that GRAM starts at position 128 in the viewer
 	x -= 128;
-	const int gram_start = 0;
-	int addr = gram_start + ((x >> 7) * 128 * 512) + (128*y) + (x % 128);
 
-	snprintf(buf, bufSize - 1, "GRAM\nADDR: 0x%X\nVAL: 0x%02X", addr, system_state->gram[addr]);
+	int hovered_pixel = ((x >> 7) * 128 * 512) + (128*y) + (x % 128);
+
+	int gram_start = 0x4000;
+	int quadrant = y >> 7;
+	int line_in_quadrant = y % 128;
+	int addr = gram_start + (128*line_in_quadrant) + (x % 128);
+
+	const char *quadrant_names[4] = {
+	  "NW",
+	  "NE",
+	  "SW",
+	  "SE"
+	};
+
+	snprintf(
+	  buf,
+	  bufSize - 1,
+	  "GRAM\nBANK: %d\nQUADRANT: %s\nADDR: 0x%X\nVAL: 0x%02X",
+	  x >> 7,
+	  quadrant_names[quadrant],
+	  addr,
+	  system_state->gram[hovered_pixel]
+        );
     }
 }

--- a/src/devtools/vram_window.cpp
+++ b/src/devtools/vram_window.cpp
@@ -42,9 +42,9 @@ void VRAMWindow::Draw() {
     src.h = 512;
     dest.h = 512;
     for(int i = 0; i < 8; i++) {
-    dest.x = (i+1) * 128;
-    src.y = i * 512;
-    SDL_BlitSurface(gRAM_Surface, &src, surface, &dest);
+	dest.x = (i+1) * 128;
+	src.y = i * 512;
+	SDL_BlitSurface(gRAM_Surface, &src, surface, &dest);
     }
 
     char buf[128];

--- a/src/devtools/vram_window.cpp
+++ b/src/devtools/vram_window.cpp
@@ -23,13 +23,7 @@ VRAMWindow::VRAMWindow(
 void VRAMWindow::Draw() {
     SDL_Rect src, dest;
 
-    // Clear the surface before re-rendering
-    dest.x = 0;
-    dest.y = 0;
-    dest.w = 128*9;
-    dest.h = 512;
-    SDL_FillRect(surface, &dest, 0);
-
+    // Render VRAM
     dest.x = 0;
     dest.y = 0;
     dest.w = 128;
@@ -39,13 +33,24 @@ void VRAMWindow::Draw() {
     src.w = 128;
     src.h = 256;
     SDL_BlitSurface(vRAM_Surface, &src, surface, &dest);
+
     src.h = 512;
     dest.h = 512;
+
+    // Render GRAM
     for(int i = 0; i < 8; i++) {
 	dest.x = (i+1) * 128;
 	src.y = i * 512;
 	SDL_BlitSurface(gRAM_Surface, &src, surface, &dest);
     }
+
+    // Render text
+    // Clear the text area before re-rendering as not all text is always rendered
+    dest.x = 0;
+    dest.y = 256;
+    dest.w = 128;
+    dest.h = 256;
+    SDL_FillRect(surface, &dest, 0);
 
     char buf[128];
 

--- a/src/devtools/vram_window.h
+++ b/src/devtools/vram_window.h
@@ -1,4 +1,5 @@
 #pragma once
+
 #include "base_window.h"
 #include "../system_state.h"
 #include "../mos6502/mos6502.h"
@@ -11,6 +12,8 @@ private:
     SystemState* system_state;
     mos6502* cpu_core;
     CartridgeState* cartridge_state;
+
+    void WriteDataUnderMouse(char *buf, int bufSize);
 public:
     VRAMWindow(SDL_Surface* vram, SDL_Surface* gram, SystemState* system, mos6502* cpu, CartridgeState* cartridge);
     void Draw();


### PR DESCRIPTION
Changes:
- Adds a title to the vram viewer
- Shows value (and address) of pixel under mouse


@clydeshaffer if you wouldn't mind making sure that the address calculations are right.  I don't know which addresses the blocks start at (or if that's even a valid idea) so I have values `vram_start` and `gram_start` just set to zero. It might not be helpful to display the address at all? If you think not we can just not bother with that

Vram hovering data
![image](https://github.com/user-attachments/assets/c6a09768-936b-4e69-98e9-9784c7ee2e85)

Gram hovering data
![Screenshot from 2024-10-14 22-22-23](https://github.com/user-attachments/assets/62c08013-0d5d-4683-add1-7971899b7b6b)

Fixes #20 