### PR TITLE
Pause emulation on tab blur

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ else ifeq ($(OS), wasm)
 	COMPILER_FLAGS += -s USE_SDL=2 -D WASM_BUILD -D EMBED_ROM_FILE='"$(ROMFILE)"'
 	DEFINES += -D DISABLE_ESC
 	BIN_NAME = index.html
-	LINKER_FLAGS += --embed-file $(ROMFILE) --shell-file $(WEB_SHELL) -s EXPORTED_FUNCTIONS='["_LoadRomFile", "_main", "_SetButtons"]' -s EXPORTED_RUNTIME_METHODS='["ccall","cwrap"]' -lidbfs.js
+	LINKER_FLAGS += --embed-file $(ROMFILE) --shell-file $(WEB_SHELL) -s EXPORTED_FUNCTIONS='["_LoadRomFile", "_main", "_SetButtons", "_PauseEmulation", "_ResumeEmulation"]' -s EXPORTED_RUNTIME_METHODS='["ccall","cwrap"]' -lidbfs.js
 	SRCS :=  $(filter-out $(foreach src,$(SRCS),$(if $(findstring imgui,$(src)), $(src))),$(SRCS))
 	SRCS := $(filter-out %window.cpp, $(SRCS))
 else

--- a/src/audio_coprocessor.cpp
+++ b/src/audio_coprocessor.cpp
@@ -40,6 +40,18 @@ void AudioCoprocessor::register_write(uint16_t address, uint8_t value) {
 void AudioCoprocessor::fill_audio(void *udata, uint8_t *stream, int len) {
     ACPState *state = (ACPState*) udata;
     uint16_t *stream16 = (uint16_t*) stream;
+
+    // If emulation is paused, just fill buffer with zeroes without advancing the apu
+    if (state->isEmulationPaused) {
+	for(int i = 0; i < len/sizeof(uint16_t); i++) {
+	    if(stream16 != NULL) {
+		stream16[i] = 0;
+	    }
+	}
+
+	return;
+    }
+
     for(int i = 0; i < len/sizeof(uint16_t); i++) {
         if(stream16 != NULL) {
             stream16[i] = state->dacReg;
@@ -151,6 +163,7 @@ AudioCoprocessor::AudioCoprocessor() {
     state.last_irq_cycles = 0;
     state.volume = 256;
     state.isMuted = false;
+    state.isEmulationPaused = false;
     state.clkMult = 4;
 
 	for(int i = 0; i < AUDIO_RAM_SIZE; i ++) {

--- a/src/audio_coprocessor.h
+++ b/src/audio_coprocessor.h
@@ -26,6 +26,7 @@ typedef struct ACPState {
 	SDL_AudioDeviceID device;
 	int volume;
 	bool isMuted;
+	bool isEmulationPaused;
 } ACPState;
 
 class AudioCoprocessor {

--- a/src/gte.cpp
+++ b/src/gte.cpp
@@ -534,6 +534,20 @@ void randomize_memory() {
 	blitter->gram_mid_bits = rand() % 4;
 }
 
+extern "C" {
+void PauseEmulation() {
+  paused = true;
+
+  AudioCoprocessor::singleton_acp_state->isEmulationPaused = true;
+}
+
+void ResumeEmulation() {
+  paused = false;
+
+  AudioCoprocessor::singleton_acp_state->isEmulationPaused = false;
+}
+}
+
 void CPUStopped() {
 	paused = true;
 	printf("CPU stopped");

--- a/web/embedded.html
+++ b/web/embedded.html
@@ -281,6 +281,18 @@
         body.addEventListener('keydown', preventScroll, false);
         body.addEventListener('click', activateCanvas, false);
         canvas.addEventListener('mousedown', handleMouseDown, false);
+
+	// Automatically suspend and resume emulation when page loses focus
+	// NOTE this shell is intended for use in an iframe.  iframes inherit visibility status from their containing document
+        document.addEventListener("visibilitychange", () => {
+          if (document.hidden) {
+            Module.ccall('PauseEmulation');
+          } else {
+            // NOTE if in the future we have other means of pausing emulation, we should not assume that we always
+            // want to resume on the page becoming visible again
+            Module.ccall('ResumeEmulation');
+          }
+        });
       }
 
     </script>

--- a/web/shell.html
+++ b/web/shell.html
@@ -300,6 +300,15 @@
       }
 
       Module.onRuntimeInitialized = function() {
+        document.addEventListener("visibilitychange", () => {
+          if (document.hidden) {
+            Module.ccall('PauseEmulation');
+          } else {
+            // NOTE if in the future we have other means of pausing emulation, we should not assume that we always
+            // want to resume on the page becoming visible again
+            Module.ccall('ResumeEmulation');
+          }
+        });
 
         var urlRomName = getParameterByName('rom');
         if(urlRomName != null) {


### PR DESCRIPTION
Browsers heavily throttle non-active flags. This is especially bad with the gametank emulator's web build as this often leads to deeply cursed audio as the audio processor is not given enough time to run.

This pr adds some simple, idempotent functions to `gte.cpp` to pause and resume emulation.  These functions are exported for use through emscripten. The browser uses a [visibilitychange](https://developer.mozilla.org/en-US/docs/Web/API/Page_Visibility_API) event on the page to call `PauseEmulation` or `ResumeEmulation` respectively.

Lmk what your thoughts on this pr are. I didn't see any other functions specifically for controlling the emulator's paused state, so I'm not sure I'm pausing everything I need to.

Note on `<iframe>`s: According to mdn, iframes inherit the visibility status of their containing page. This means that if you tab away from an itch page with an emulator running the embedded emulator iframe also receives the visibilitychange event. I haven't updated the embedded shell in this pr to also feature pausing functionality, but I could if you want.

---
Update: pause/ resume functionality has been added to the embedded shell