### PR TITLE
Conditional timing

### DIFF
--- a/src/mos6502/mos6502.cpp
+++ b/src/mos6502/mos6502.cpp
@@ -693,7 +693,7 @@ mos6502::AddrRes mos6502::Addr_ABI()
 
 	addr = effL + 0x100 * effH;
 
-	return AddrRes { 5, addr };
+	return AddrRes { 6, addr };
 }
 
 mos6502::AddrRes mos6502::Addr_ZEX()
@@ -1282,12 +1282,11 @@ uint8_t mos6502::Op_INY(uint16_t src)
 	return 2;
 }
 
-// FIXME JMP should take one *less* cycle if in ABS mode
 uint8_t mos6502::Op_JMP(uint16_t src)
 {
 	pc = src;
 
-	return 0;
+	return -1;
 }
 
 uint8_t mos6502::Op_JSR(uint16_t src)

--- a/src/mos6502/mos6502.cpp
+++ b/src/mos6502/mos6502.cpp
@@ -22,770 +22,594 @@ mos6502::mos6502(BusRead r, BusWrite w, CPUEvent stp, BusRead sync)
 
 	instr.addr = &mos6502::Addr_IMM;
 	instr.code = &mos6502::Op_ADC;
-	instr.cycles = 2;
 	InstrTable[0x69] = instr;
 	instr.addr = &mos6502::Addr_ABS;
 	instr.code = &mos6502::Op_ADC;
-	instr.cycles = 4;
 	InstrTable[0x6D] = instr;
 	instr.addr = &mos6502::Addr_ZER;
 	instr.code = &mos6502::Op_ADC;
-	instr.cycles = 3;
 	InstrTable[0x65] = instr;
 	instr.addr = &mos6502::Addr_INX;
 	instr.code = &mos6502::Op_ADC;
-	instr.cycles = 6;
 	InstrTable[0x61] = instr;
 	instr.addr = &mos6502::Addr_INY;
 	instr.code = &mos6502::Op_ADC;
-	instr.cycles = 6;
 	InstrTable[0x71] = instr;
 	instr.addr = &mos6502::Addr_ZEX;
 	instr.code = &mos6502::Op_ADC;
-	instr.cycles = 4;
 	InstrTable[0x75] = instr;
 	instr.addr = &mos6502::Addr_ABX;
 	instr.code = &mos6502::Op_ADC;
-	instr.cycles = 4;
 	InstrTable[0x7D] = instr;
 	instr.addr = &mos6502::Addr_ABY;
 	instr.code = &mos6502::Op_ADC;
-	instr.cycles = 4;
 	InstrTable[0x79] = instr;
 	instr.addr = &mos6502::Addr_ZPI;
 	instr.code = &mos6502::Op_ADC;
-	instr.cycles = 6;
 	InstrTable[0x72] = instr;
 
 	instr.addr = &mos6502::Addr_IMM;
 	instr.code = &mos6502::Op_AND;
-	instr.cycles = 2;
 	InstrTable[0x29] = instr;
 	instr.addr = &mos6502::Addr_ABS;
 	instr.code = &mos6502::Op_AND;
-	instr.cycles = 4;
 	InstrTable[0x2D] = instr;
 	instr.addr = &mos6502::Addr_ZER;
 	instr.code = &mos6502::Op_AND;
-	instr.cycles = 3;
 	InstrTable[0x25] = instr;
 	instr.addr = &mos6502::Addr_INX;
 	instr.code = &mos6502::Op_AND;
-	instr.cycles = 6;
 	InstrTable[0x21] = instr;
 	instr.addr = &mos6502::Addr_INY;
 	instr.code = &mos6502::Op_AND;
-	instr.cycles = 5;
 	InstrTable[0x31] = instr;
 	instr.addr = &mos6502::Addr_ZEX;
 	instr.code = &mos6502::Op_AND;
-	instr.cycles = 4;
 	InstrTable[0x35] = instr;
 	instr.addr = &mos6502::Addr_ABX;
 	instr.code = &mos6502::Op_AND;
-	instr.cycles = 4;
 	InstrTable[0x3D] = instr;
 	instr.addr = &mos6502::Addr_ABY;
 	instr.code = &mos6502::Op_AND;
-	instr.cycles = 4;
 	InstrTable[0x39] = instr;
 	instr.addr = &mos6502::Addr_ZPI;
 	instr.code = &mos6502::Op_AND;
-	instr.cycles = 5;
 	InstrTable[0x32] = instr;
 
 	instr.addr = &mos6502::Addr_ABS;
 	instr.code = &mos6502::Op_ASL;
-	instr.cycles = 6;
 	InstrTable[0x0E] = instr;
 	instr.addr = &mos6502::Addr_ZER;
 	instr.code = &mos6502::Op_ASL;
-	instr.cycles = 5;
 	InstrTable[0x06] = instr;
 	instr.addr = &mos6502::Addr_ACC;
 	instr.code = &mos6502::Op_ASL_ACC;
-	instr.cycles = 2;
 	InstrTable[0x0A] = instr;
 	instr.addr = &mos6502::Addr_ZEX;
 	instr.code = &mos6502::Op_ASL;
-	instr.cycles = 6;
 	InstrTable[0x16] = instr;
 	instr.addr = &mos6502::Addr_ABX;
 	instr.code = &mos6502::Op_ASL;
-	instr.cycles = 7;
 	InstrTable[0x1E] = instr;
 
 	instr.addr = &mos6502::Addr_REL;
 	instr.code = &mos6502::Op_BCC;
-	instr.cycles = 2;
 	InstrTable[0x90] = instr;
 
 	instr.addr = &mos6502::Addr_REL;
 	instr.code = &mos6502::Op_BCS;
-	instr.cycles = 2;
 	InstrTable[0xB0] = instr;
 
 	instr.addr = &mos6502::Addr_REL;
 	instr.code = &mos6502::Op_BEQ;
-	instr.cycles = 2;
 	InstrTable[0xF0] = instr;
 
 	instr.addr = &mos6502::Addr_REL;
 	instr.code = &mos6502::Op_BRA;
-	instr.cycles = 3;
 	InstrTable[0x80] = instr;
 
 	instr.addr = &mos6502::Addr_ABS;
 	instr.code = &mos6502::Op_BIT;
-	instr.cycles = 4;
 	InstrTable[0x2C] = instr;
 	instr.addr = &mos6502::Addr_ZER;
 	instr.code = &mos6502::Op_BIT;
-	instr.cycles = 3;
 	InstrTable[0x24] = instr;
 
 	instr.addr = &mos6502::Addr_REL;
 	instr.code = &mos6502::Op_BMI;
-	instr.cycles = 2;
 	InstrTable[0x30] = instr;
 
 	instr.addr = &mos6502::Addr_REL;
 	instr.code = &mos6502::Op_BNE;
-	instr.cycles = 2;
 	InstrTable[0xD0] = instr;
 
 	instr.addr = &mos6502::Addr_REL;
 	instr.code = &mos6502::Op_BPL;
-	instr.cycles = 2;
 	InstrTable[0x10] = instr;
 
 	instr.addr = &mos6502::Addr_IMP;
 	instr.code = &mos6502::Op_BRK;
-	instr.cycles = 7;
 	InstrTable[0x00] = instr;
 
 	instr.addr = &mos6502::Addr_REL;
 	instr.code = &mos6502::Op_BVC;
-	instr.cycles = 2;
 	InstrTable[0x50] = instr;
 
 	instr.addr = &mos6502::Addr_REL;
 	instr.code = &mos6502::Op_BVS;
-	instr.cycles = 2;
 	InstrTable[0x70] = instr;
 
 	instr.addr = &mos6502::Addr_IMP;
 	instr.code = &mos6502::Op_CLC;
-	instr.cycles = 2;
 	InstrTable[0x18] = instr;
 
 	instr.addr = &mos6502::Addr_IMP;
 	instr.code = &mos6502::Op_CLD;
-	instr.cycles = 2;
 	InstrTable[0xD8] = instr;
 
 	instr.addr = &mos6502::Addr_IMP;
 	instr.code = &mos6502::Op_CLI;
-	instr.cycles = 2;
 	InstrTable[0x58] = instr;
 
 	instr.addr = &mos6502::Addr_IMP;
 	instr.code = &mos6502::Op_CLV;
-	instr.cycles = 2;
 	InstrTable[0xB8] = instr;
 
 	instr.addr = &mos6502::Addr_IMM;
 	instr.code = &mos6502::Op_CMP;
-	instr.cycles = 2;
 	InstrTable[0xC9] = instr;
 	instr.addr = &mos6502::Addr_IMP;
 	instr.code = &mos6502::Op_WAI;
-	instr.cycles = 3;
 	InstrTable[0xCB] = instr;
 	instr.addr = &mos6502::Addr_IMP;
 	instr.code = &mos6502::Op_STP;
-	instr.cycles = 3;
 	InstrTable[0xDB] = instr;
 	instr.addr = &mos6502::Addr_ABS;
 	instr.code = &mos6502::Op_CMP;
-	instr.cycles = 4;
 	InstrTable[0xCD] = instr;
 	instr.addr = &mos6502::Addr_ZER;
 	instr.code = &mos6502::Op_CMP;
-	instr.cycles = 3;
 	InstrTable[0xC5] = instr;
 	instr.addr = &mos6502::Addr_INX;
 	instr.code = &mos6502::Op_CMP;
-	instr.cycles = 6;
 	InstrTable[0xC1] = instr;
 	instr.addr = &mos6502::Addr_INY;
 	instr.code = &mos6502::Op_CMP;
-	instr.cycles = 3;
 	InstrTable[0xD1] = instr;
 	instr.addr = &mos6502::Addr_ZEX;
 	instr.code = &mos6502::Op_CMP;
-	instr.cycles = 4;
 	InstrTable[0xD5] = instr;
 	instr.addr = &mos6502::Addr_ABX;
 	instr.code = &mos6502::Op_CMP;
-	instr.cycles = 4;
 	InstrTable[0xDD] = instr;
 	instr.addr = &mos6502::Addr_ABY;
 	instr.code = &mos6502::Op_CMP;
-	instr.cycles = 4;
 	InstrTable[0xD9] = instr;
 	instr.addr = &mos6502::Addr_ZPI;
 	instr.code = &mos6502::Op_CMP;
-	instr.cycles = 5;
 	InstrTable[0xD2] = instr;
 
 	instr.addr = &mos6502::Addr_IMM;
 	instr.code = &mos6502::Op_CPX;
-	instr.cycles = 2;
 	InstrTable[0xE0] = instr;
 	instr.addr = &mos6502::Addr_ABS;
 	instr.code = &mos6502::Op_CPX;
-	instr.cycles = 4;
 	InstrTable[0xEC] = instr;
 	instr.addr = &mos6502::Addr_ZER;
 	instr.code = &mos6502::Op_CPX;
-	instr.cycles = 3;
 	InstrTable[0xE4] = instr;
 
 	instr.addr = &mos6502::Addr_IMM;
 	instr.code = &mos6502::Op_CPY;
-	instr.cycles = 2;
 	InstrTable[0xC0] = instr;
 	instr.addr = &mos6502::Addr_ABS;
 	instr.code = &mos6502::Op_CPY;
-	instr.cycles = 4;
 	InstrTable[0xCC] = instr;
 	instr.addr = &mos6502::Addr_ZER;
 	instr.code = &mos6502::Op_CPY;
-	instr.cycles = 3;
 	InstrTable[0xC4] = instr;
 
 	instr.addr = &mos6502::Addr_IMP;
 	instr.code = &mos6502::Op_DEC_ACC;
-	instr.cycles = 2;
 	InstrTable[0x3A] = instr;
 	instr.addr = &mos6502::Addr_ABS;
 	instr.code = &mos6502::Op_DEC;
-	instr.cycles = 6;
 	InstrTable[0xCE] = instr;
 	instr.addr = &mos6502::Addr_ZER;
 	instr.code = &mos6502::Op_DEC;
-	instr.cycles = 5;
 	InstrTable[0xC6] = instr;
 	instr.addr = &mos6502::Addr_ZEX;
 	instr.code = &mos6502::Op_DEC;
-	instr.cycles = 6;
 	InstrTable[0xD6] = instr;
 	instr.addr = &mos6502::Addr_ABX;
 	instr.code = &mos6502::Op_DEC;
-	instr.cycles = 7;
 	InstrTable[0xDE] = instr;
 
 	instr.addr = &mos6502::Addr_IMP;
 	instr.code = &mos6502::Op_DEX;
-	instr.cycles = 2;
 	InstrTable[0xCA] = instr;
 
 	instr.addr = &mos6502::Addr_IMP;
 	instr.code = &mos6502::Op_DEY;
-	instr.cycles = 2;
 	InstrTable[0x88] = instr;
 
 	instr.addr = &mos6502::Addr_IMM;
 	instr.code = &mos6502::Op_EOR;
-	instr.cycles = 2;
 	InstrTable[0x49] = instr;
 	instr.addr = &mos6502::Addr_ABS;
 	instr.code = &mos6502::Op_EOR;
-	instr.cycles = 4;
 	InstrTable[0x4D] = instr;
 	instr.addr = &mos6502::Addr_ZER;
 	instr.code = &mos6502::Op_EOR;
-	instr.cycles = 3;
 	InstrTable[0x45] = instr;
 	instr.addr = &mos6502::Addr_INX;
 	instr.code = &mos6502::Op_EOR;
-	instr.cycles = 6;
 	InstrTable[0x41] = instr;
 	instr.addr = &mos6502::Addr_INY;
 	instr.code = &mos6502::Op_EOR;
-	instr.cycles = 5;
 	InstrTable[0x51] = instr;
 	instr.addr = &mos6502::Addr_ZEX;
 	instr.code = &mos6502::Op_EOR;
-	instr.cycles = 4;
 	InstrTable[0x55] = instr;
 	instr.addr = &mos6502::Addr_ABX;
 	instr.code = &mos6502::Op_EOR;
-	instr.cycles = 4;
 	InstrTable[0x5D] = instr;
 	instr.addr = &mos6502::Addr_ABY;
 	instr.code = &mos6502::Op_EOR;
-	instr.cycles = 4;
 	InstrTable[0x59] = instr;
 	instr.addr = &mos6502::Addr_ZPI;
 	instr.code = &mos6502::Op_EOR;
-	instr.cycles = 5;
 	InstrTable[0x52] = instr;
 
 	instr.addr = &mos6502::Addr_IMP;
 	instr.code = &mos6502::Op_INC_ACC;
-	instr.cycles = 2;
 	InstrTable[0x1A] = instr;
 	instr.addr = &mos6502::Addr_ABS;
 	instr.code = &mos6502::Op_INC;
-	instr.cycles = 6;
 	InstrTable[0xEE] = instr;
 	instr.addr = &mos6502::Addr_ZER;
 	instr.code = &mos6502::Op_INC;
-	instr.cycles = 5;
 	InstrTable[0xE6] = instr;
 	instr.addr = &mos6502::Addr_ZEX;
 	instr.code = &mos6502::Op_INC;
-	instr.cycles = 6;
 	InstrTable[0xF6] = instr;
 	instr.addr = &mos6502::Addr_ABX;
 	instr.code = &mos6502::Op_INC;
-	instr.cycles = 7;
 	InstrTable[0xFE] = instr;
 
 	instr.addr = &mos6502::Addr_IMP;
 	instr.code = &mos6502::Op_INX;
-	instr.cycles = 2;
 	InstrTable[0xE8] = instr;
 
 	instr.addr = &mos6502::Addr_IMP;
 	instr.code = &mos6502::Op_INY;
-	instr.cycles = 2;
 	InstrTable[0xC8] = instr;
 
 	instr.addr = &mos6502::Addr_ABS;
 	instr.code = &mos6502::Op_JMP;
-	instr.cycles = 3;
 	InstrTable[0x4C] = instr;
 	instr.addr = &mos6502::Addr_ABI;
 	instr.code = &mos6502::Op_JMP;
-	instr.cycles = 5;
 	InstrTable[0x6C] = instr;
 
 	instr.addr = &mos6502::Addr_ABS;
 	instr.code = &mos6502::Op_JSR;
-	instr.cycles = 6;
 	InstrTable[0x20] = instr;
 
 	instr.addr = &mos6502::Addr_IMM;
 	instr.code = &mos6502::Op_LDA;
-	instr.cycles = 2;
 	InstrTable[0xA9] = instr;
 	instr.addr = &mos6502::Addr_ABS;
 	instr.code = &mos6502::Op_LDA;
-	instr.cycles = 4;
 	InstrTable[0xAD] = instr;
 	instr.addr = &mos6502::Addr_ZER;
 	instr.code = &mos6502::Op_LDA;
-	instr.cycles = 3;
 	InstrTable[0xA5] = instr;
 	instr.addr = &mos6502::Addr_INX;
 	instr.code = &mos6502::Op_LDA;
-	instr.cycles = 6;
 	InstrTable[0xA1] = instr;
 	instr.addr = &mos6502::Addr_INY;
 	instr.code = &mos6502::Op_LDA;
-	instr.cycles = 5;
 	InstrTable[0xB1] = instr;
 	instr.addr = &mos6502::Addr_ZEX;
 	instr.code = &mos6502::Op_LDA;
-	instr.cycles = 4;
 	InstrTable[0xB5] = instr;
 	instr.addr = &mos6502::Addr_ABX;
 	instr.code = &mos6502::Op_LDA;
-	instr.cycles = 4;
 	InstrTable[0xBD] = instr;
 	instr.addr = &mos6502::Addr_ABY;
 	instr.code = &mos6502::Op_LDA;
-	instr.cycles = 4;
 	InstrTable[0xB9] = instr;
 	instr.addr = &mos6502::Addr_ZPI;
 	instr.code = &mos6502::Op_LDA;
-	instr.cycles = 5;
 	InstrTable[0xB2] = instr;
 
 	instr.addr = &mos6502::Addr_IMM;
 	instr.code = &mos6502::Op_LDX;
-	instr.cycles = 2;
 	InstrTable[0xA2] = instr;
 	instr.addr = &mos6502::Addr_ABS;
 	instr.code = &mos6502::Op_LDX;
-	instr.cycles = 4;
 	InstrTable[0xAE] = instr;
 	instr.addr = &mos6502::Addr_ZER;
 	instr.code = &mos6502::Op_LDX;
-	instr.cycles = 3;
 	InstrTable[0xA6] = instr;
 	instr.addr = &mos6502::Addr_ABY;
 	instr.code = &mos6502::Op_LDX;
-	instr.cycles = 4;
 	InstrTable[0xBE] = instr;
 	instr.addr = &mos6502::Addr_ZEY;
 	instr.code = &mos6502::Op_LDX;
-	instr.cycles = 4;
 	InstrTable[0xB6] = instr;
 
 	instr.addr = &mos6502::Addr_IMM;
 	instr.code = &mos6502::Op_LDY;
-	instr.cycles = 2;
 	InstrTable[0xA0] = instr;
 	instr.addr = &mos6502::Addr_ABS;
 	instr.code = &mos6502::Op_LDY;
-	instr.cycles = 4;
 	InstrTable[0xAC] = instr;
 	instr.addr = &mos6502::Addr_ZER;
 	instr.code = &mos6502::Op_LDY;
-	instr.cycles = 3;
 	InstrTable[0xA4] = instr;
 	instr.addr = &mos6502::Addr_ZEX;
 	instr.code = &mos6502::Op_LDY;
-	instr.cycles = 4;
 	InstrTable[0xB4] = instr;
 	instr.addr = &mos6502::Addr_ABX;
 	instr.code = &mos6502::Op_LDY;
-	instr.cycles = 4;
 	InstrTable[0xBC] = instr;
 
 	instr.addr = &mos6502::Addr_ABS;
 	instr.code = &mos6502::Op_LSR;
-	instr.cycles = 6;
 	InstrTable[0x4E] = instr;
 	instr.addr = &mos6502::Addr_ZER;
 	instr.code = &mos6502::Op_LSR;
-	instr.cycles = 5;
 	InstrTable[0x46] = instr;
 	instr.addr = &mos6502::Addr_ACC;
 	instr.code = &mos6502::Op_LSR_ACC;
-	instr.cycles = 2;
 	InstrTable[0x4A] = instr;
 	instr.addr = &mos6502::Addr_ZEX;
 	instr.code = &mos6502::Op_LSR;
-	instr.cycles = 6;
 	InstrTable[0x56] = instr;
 	instr.addr = &mos6502::Addr_ABX;
 	instr.code = &mos6502::Op_LSR;
-	instr.cycles = 7;
 	InstrTable[0x5E] = instr;
 
 	instr.addr = &mos6502::Addr_IMP;
 	instr.code = &mos6502::Op_NOP;
-	instr.cycles = 2;
 	InstrTable[0xEA] = instr;
 
 	instr.addr = &mos6502::Addr_IMM;
 	instr.code = &mos6502::Op_ORA;
-	instr.cycles = 2;
 	InstrTable[0x09] = instr;
 	instr.addr = &mos6502::Addr_ABS;
 	instr.code = &mos6502::Op_ORA;
-	instr.cycles = 4;
 	InstrTable[0x0D] = instr;
 	instr.addr = &mos6502::Addr_ZER;
 	instr.code = &mos6502::Op_ORA;
-	instr.cycles = 3;
 	InstrTable[0x05] = instr;
 	instr.addr = &mos6502::Addr_INX;
 	instr.code = &mos6502::Op_ORA;
-	instr.cycles = 6;
 	InstrTable[0x01] = instr;
 	instr.addr = &mos6502::Addr_INY;
 	instr.code = &mos6502::Op_ORA;
-	instr.cycles = 5;
 	InstrTable[0x11] = instr;
 	instr.addr = &mos6502::Addr_ZEX;
 	instr.code = &mos6502::Op_ORA;
-	instr.cycles = 4;
 	InstrTable[0x15] = instr;
 	instr.addr = &mos6502::Addr_ABX;
 	instr.code = &mos6502::Op_ORA;
-	instr.cycles = 4;
 	InstrTable[0x1D] = instr;
 	instr.addr = &mos6502::Addr_ABY;
 	instr.code = &mos6502::Op_ORA;
-	instr.cycles = 4;
 	InstrTable[0x19] = instr;
 	instr.addr = &mos6502::Addr_ZPI;
 	instr.code = &mos6502::Op_ORA;
-	instr.cycles = 5;
 	InstrTable[0x12] = instr;
 
 	instr.addr = &mos6502::Addr_IMP;
 	instr.code = &mos6502::Op_PHA;
-	instr.cycles = 3;
 	InstrTable[0x48] = instr;
 
 	instr.addr = &mos6502::Addr_IMP;
 	instr.code = &mos6502::Op_PHP;
-	instr.cycles = 3;
 	InstrTable[0x08] = instr;
 
 	instr.addr = &mos6502::Addr_IMP;
 	instr.code = &mos6502::Op_PHX;
-	instr.cycles = 3;
 	InstrTable[0xDA] = instr;
 
 	instr.addr = &mos6502::Addr_IMP;
 	instr.code = &mos6502::Op_PHY;
-	instr.cycles = 3;
 	InstrTable[0x5A] = instr;
 
 	instr.addr = &mos6502::Addr_IMP;
 	instr.code = &mos6502::Op_PLA;
-	instr.cycles = 4;
 	InstrTable[0x68] = instr;
 
 	instr.addr = &mos6502::Addr_IMP;
 	instr.code = &mos6502::Op_PLP;
-	instr.cycles = 4;
 	InstrTable[0x28] = instr;
 
 	instr.addr = &mos6502::Addr_IMP;
 	instr.code = &mos6502::Op_PLX;
-	instr.cycles = 4;
 	InstrTable[0xFA] = instr;
 
 	instr.addr = &mos6502::Addr_IMP;
 	instr.code = &mos6502::Op_PLY;
-	instr.cycles = 4;
 	InstrTable[0x7A] = instr;
 
 	instr.addr = &mos6502::Addr_ABS;
 	instr.code = &mos6502::Op_ROL;
-	instr.cycles = 6;
 	InstrTable[0x2E] = instr;
 	instr.addr = &mos6502::Addr_ZER;
 	instr.code = &mos6502::Op_ROL;
-	instr.cycles = 5;
 	InstrTable[0x26] = instr;
 	instr.addr = &mos6502::Addr_ACC;
 	instr.code = &mos6502::Op_ROL_ACC;
-	instr.cycles = 2;
 	InstrTable[0x2A] = instr;
 	instr.addr = &mos6502::Addr_ZEX;
 	instr.code = &mos6502::Op_ROL;
-	instr.cycles = 6;
 	InstrTable[0x36] = instr;
 	instr.addr = &mos6502::Addr_ABX;
 	instr.code = &mos6502::Op_ROL;
-	instr.cycles = 7;
 	InstrTable[0x3E] = instr;
 
 	instr.addr = &mos6502::Addr_ABS;
 	instr.code = &mos6502::Op_ROR;
-	instr.cycles = 6;
 	InstrTable[0x6E] = instr;
 	instr.addr = &mos6502::Addr_ZER;
 	instr.code = &mos6502::Op_ROR;
-	instr.cycles = 5;
 	InstrTable[0x66] = instr;
 	instr.addr = &mos6502::Addr_ACC;
 	instr.code = &mos6502::Op_ROR_ACC;
-	instr.cycles = 2;
 	InstrTable[0x6A] = instr;
 	instr.addr = &mos6502::Addr_ZEX;
 	instr.code = &mos6502::Op_ROR;
-	instr.cycles = 6;
 	InstrTable[0x76] = instr;
 	instr.addr = &mos6502::Addr_ABX;
 	instr.code = &mos6502::Op_ROR;
-	instr.cycles = 7;
 	InstrTable[0x7E] = instr;
 
 	instr.addr = &mos6502::Addr_IMP;
 	instr.code = &mos6502::Op_RTI;
-	instr.cycles = 6;
 	InstrTable[0x40] = instr;
 
 	instr.addr = &mos6502::Addr_IMP;
 	instr.code = &mos6502::Op_RTS;
-	instr.cycles = 6;
 	InstrTable[0x60] = instr;
 
 	instr.addr = &mos6502::Addr_IMM;
 	instr.code = &mos6502::Op_SBC;
-	instr.cycles = 2;
 	InstrTable[0xE9] = instr;
 	instr.addr = &mos6502::Addr_ABS;
 	instr.code = &mos6502::Op_SBC;
-	instr.cycles = 4;
 	InstrTable[0xED] = instr;
 	instr.addr = &mos6502::Addr_ZER;
 	instr.code = &mos6502::Op_SBC;
-	instr.cycles = 3;
 	InstrTable[0xE5] = instr;
 	instr.addr = &mos6502::Addr_INX;
 	instr.code = &mos6502::Op_SBC;
-	instr.cycles = 6;
 	InstrTable[0xE1] = instr;
 	instr.addr = &mos6502::Addr_INY;
 	instr.code = &mos6502::Op_SBC;
-	instr.cycles = 5;
 	InstrTable[0xF1] = instr;
 	instr.addr = &mos6502::Addr_ZEX;
 	instr.code = &mos6502::Op_SBC;
-	instr.cycles = 4;
 	InstrTable[0xF5] = instr;
 	instr.addr = &mos6502::Addr_ABX;
 	instr.code = &mos6502::Op_SBC;
-	instr.cycles = 4;
 	InstrTable[0xFD] = instr;
 	instr.addr = &mos6502::Addr_ABY;
 	instr.code = &mos6502::Op_SBC;
-	instr.cycles = 4;
 	InstrTable[0xF9] = instr;
 	instr.addr = &mos6502::Addr_ZPI;
 	instr.code = &mos6502::Op_SBC;
-	instr.cycles = 5;
 	InstrTable[0xF2] = instr;
 
 	instr.addr = &mos6502::Addr_IMP;
 	instr.code = &mos6502::Op_SEC;
-	instr.cycles = 2;
 	InstrTable[0x38] = instr;
 
 	instr.addr = &mos6502::Addr_IMP;
 	instr.code = &mos6502::Op_SED;
-	instr.cycles = 2;
 	InstrTable[0xF8] = instr;
 
 	instr.addr = &mos6502::Addr_IMP;
 	instr.code = &mos6502::Op_SEI;
-	instr.cycles = 2;
 	InstrTable[0x78] = instr;
 
 	instr.addr = &mos6502::Addr_ABS;
 	instr.code = &mos6502::Op_STA;
-	instr.cycles = 4;
 	InstrTable[0x8D] = instr;
 	instr.addr = &mos6502::Addr_ZER;
 	instr.code = &mos6502::Op_STA;
-	instr.cycles = 3;
 	InstrTable[0x85] = instr;
 	instr.addr = &mos6502::Addr_INX;
 	instr.code = &mos6502::Op_STA;
-	instr.cycles = 6;
 	InstrTable[0x81] = instr;
 	instr.addr = &mos6502::Addr_INY;
 	instr.code = &mos6502::Op_STA;
-	instr.cycles = 6;
 	InstrTable[0x91] = instr;
 	instr.addr = &mos6502::Addr_ZEX;
 	instr.code = &mos6502::Op_STA;
-	instr.cycles = 4;
 	InstrTable[0x95] = instr;
 	instr.addr = &mos6502::Addr_ABX;
 	instr.code = &mos6502::Op_STA;
-	instr.cycles = 5;
 	InstrTable[0x9D] = instr;
 	instr.addr = &mos6502::Addr_ABY;
 	instr.code = &mos6502::Op_STA;
-	instr.cycles = 5;
 	InstrTable[0x99] = instr;
 	instr.addr = &mos6502::Addr_ZPI;
 	instr.code = &mos6502::Op_STA;
-	instr.cycles = 5;
 	InstrTable[0x92] = instr;
 
 	instr.addr = &mos6502::Addr_ZER;
 	instr.code = &mos6502::Op_STZ;
-	instr.cycles = 3;
 	InstrTable[0x64] = instr;
 	instr.addr = &mos6502::Addr_ZEX;
 	instr.code = &mos6502::Op_STZ;
-	instr.cycles = 4;
 	InstrTable[0x74] = instr;
 	instr.addr = &mos6502::Addr_ABS;
 	instr.code = &mos6502::Op_STZ;
-	instr.cycles = 4;
 	InstrTable[0x9C] = instr;
 	instr.addr = &mos6502::Addr_ABX;
 	instr.code = &mos6502::Op_STZ;
-	instr.cycles = 5;
 	InstrTable[0x9E] = instr;
 
 	instr.addr = &mos6502::Addr_ABS;
 	instr.code = &mos6502::Op_STX;
-	instr.cycles = 4;
 	InstrTable[0x8E] = instr;
 	instr.addr = &mos6502::Addr_ZER;
 	instr.code = &mos6502::Op_STX;
-	instr.cycles = 3;
 	InstrTable[0x86] = instr;
 	instr.addr = &mos6502::Addr_ZEY;
 	instr.code = &mos6502::Op_STX;
-	instr.cycles = 4;
 	InstrTable[0x96] = instr;
 
 	instr.addr = &mos6502::Addr_ABS;
 	instr.code = &mos6502::Op_STY;
-	instr.cycles = 4;
 	InstrTable[0x8C] = instr;
 	instr.addr = &mos6502::Addr_ZER;
 	instr.code = &mos6502::Op_STY;
-	instr.cycles = 3;
 	InstrTable[0x84] = instr;
 	instr.addr = &mos6502::Addr_ZEX;
 	instr.code = &mos6502::Op_STY;
-	instr.cycles = 4;
 	InstrTable[0x94] = instr;
 
 	instr.addr = &mos6502::Addr_IMP;
 	instr.code = &mos6502::Op_TAX;
-	instr.cycles = 2;
 	InstrTable[0xAA] = instr;
 
 	instr.addr = &mos6502::Addr_IMP;
 	instr.code = &mos6502::Op_TAY;
-	instr.cycles = 2;
 	InstrTable[0xA8] = instr;
 
 	instr.addr = &mos6502::Addr_IMP;
 	instr.code = &mos6502::Op_TSX;
-	instr.cycles = 2;
 	InstrTable[0xBA] = instr;
 
 	instr.addr = &mos6502::Addr_IMP;
 	instr.code = &mos6502::Op_TXA;
-	instr.cycles = 2;
 	InstrTable[0x8A] = instr;
 
 	instr.addr = &mos6502::Addr_IMP;
 	instr.code = &mos6502::Op_TXS;
-	instr.cycles = 2;
 	InstrTable[0x9A] = instr;
 
 	instr.addr = &mos6502::Addr_IMP;
 	instr.code = &mos6502::Op_TYA;
-	instr.cycles = 2;
 	InstrTable[0x98] = instr;
 
 	instr.addr = &mos6502::Addr_ABS;
 	instr.code = &mos6502::Op_TRB;
-	instr.cycles = 6;
 	InstrTable[0x1C] = instr;
 	instr.addr = &mos6502::Addr_ZER;
 	instr.code = &mos6502::Op_TRB;
-	instr.cycles = 5;
 	InstrTable[0x14] = instr;
 
 	instr.addr = &mos6502::Addr_ABS;
 	instr.code = &mos6502::Op_TSB;
-	instr.cycles = 6;
 	InstrTable[0x0C] = instr;
 	instr.addr = &mos6502::Addr_ZER;
 	instr.code = &mos6502::Op_TSB;
-	instr.cycles = 5;
 	InstrTable[0x04] = instr;
 
 
@@ -794,17 +618,18 @@ mos6502::mos6502(BusRead r, BusWrite w, CPUEvent stp, BusRead sync)
 	return;
 }
 
-uint16_t mos6502::Addr_ACC()
+mos6502::AddrRes mos6502::Addr_ACC()
 {
-	return 0; // not used
+	// src not used
+	return AddrRes { 2, 0 };
 }
 
-uint16_t mos6502::Addr_IMM()
+mos6502::AddrRes mos6502::Addr_IMM()
 {
-	return pc++;
+	return AddrRes { 2, pc++ };
 }
 
-uint16_t mos6502::Addr_ABS()
+mos6502::AddrRes mos6502::Addr_ABS()
 {
 	uint16_t addrL;
 	uint16_t addrH;
@@ -815,20 +640,24 @@ uint16_t mos6502::Addr_ABS()
 
 	addr = addrL + (addrH << 8);
 
-	return addr;
+	return AddrRes { 4, addr };
 }
 
-uint16_t mos6502::Addr_ZER()
+mos6502::AddrRes mos6502::Addr_ZER()
 {
-	return Read(pc++);
+  return AddrRes { 3, Read(pc++) };
 }
 
-uint16_t mos6502::Addr_IMP()
+mos6502::AddrRes mos6502::Addr_IMP()
 {
-	return 0; // not used
+	// src not used
+	// Operations which use implied addressing vary too much in cycle count
+	// so the cycles will be calculated exclusively on a per instruction basis
+	return AddrRes { 0, 0 };
 }
 
-uint16_t mos6502::Addr_REL()
+// FIXME an additional cycle should be taken if crossing a page boundry
+mos6502::AddrRes mos6502::Addr_REL()
 {
 	uint16_t offset;
 	uint16_t addr;
@@ -836,10 +665,11 @@ uint16_t mos6502::Addr_REL()
 	offset = (uint16_t)Read(pc++);
 	if (offset & 0x80) offset |= 0xFF00;
 	addr = pc + (int16_t)offset;
-	return addr;
+
+	return AddrRes { 2, addr };
 }
 
-uint16_t mos6502::Addr_ABI()
+mos6502::AddrRes mos6502::Addr_ABI()
 {
 	uint16_t addrL;
 	uint16_t addrH;
@@ -863,22 +693,23 @@ uint16_t mos6502::Addr_ABI()
 
 	addr = effL + 0x100 * effH;
 
-	return addr;
+	return AddrRes { 5, addr };
 }
 
-uint16_t mos6502::Addr_ZEX()
+mos6502::AddrRes mos6502::Addr_ZEX()
 {
 	uint16_t addr = (Read(pc++) + X) % 256;
-	return addr;
+	return AddrRes { 4, addr };
 }
 
-uint16_t mos6502::Addr_ZEY()
+mos6502::AddrRes mos6502::Addr_ZEY()
 {
 	uint16_t addr = (Read(pc++) + Y) % 256;
-	return addr;
+	return AddrRes { 4, addr };
 }
 
-uint16_t mos6502::Addr_ABX()
+// FIXME An additional cycle must be taken if a page boundry is crossed!
+mos6502::AddrRes mos6502::Addr_ABX()
 {
 	uint16_t addr;
 	uint16_t addrL;
@@ -888,10 +719,11 @@ uint16_t mos6502::Addr_ABX()
 	addrH = Read(pc++);
 
 	addr = addrL + (addrH << 8) + X;
-	return addr;
+	return AddrRes { 4, addr };
 }
 
-uint16_t mos6502::Addr_ABY()
+// FIXME An additional cycle must be taken if a page boundry is crossed!
+mos6502::AddrRes mos6502::Addr_ABY()
 {
 	uint16_t addr;
 	uint16_t addrL;
@@ -901,11 +733,11 @@ uint16_t mos6502::Addr_ABY()
 	addrH = Read(pc++);
 
 	addr = addrL + (addrH << 8) + Y;
-	return addr;
+	return AddrRes { 4, addr };
 }
 
 
-uint16_t mos6502::Addr_INX()
+mos6502::AddrRes mos6502::Addr_INX()
 {
 	uint16_t zeroL;
 	uint16_t zeroH;
@@ -915,10 +747,12 @@ uint16_t mos6502::Addr_INX()
 	zeroH = (zeroL + 1) % 256;
 	addr = Read(zeroL) + (Read(zeroH) << 8);
 
-	return addr;
+	return AddrRes { 6, addr };
 }
 
-uint16_t mos6502::Addr_INY()
+// FIXME An additional cycle must be taken if a page boundry is crossed!
+// Unless this is an STA instruction, in which case it will always take 6 cycles
+mos6502::AddrRes mos6502::Addr_INY()
 {
 	uint16_t zeroL;
 	uint16_t zeroH;
@@ -928,10 +762,10 @@ uint16_t mos6502::Addr_INY()
 	zeroH = (zeroL + 1) % 256;
 	addr = Read(zeroL) + (Read(zeroH) << 8) + Y;
 
-	return addr;
+	return AddrRes { 5, addr };
 }
 
-uint16_t mos6502::Addr_ZPI()
+mos6502::AddrRes mos6502::Addr_ZPI()
 {
 	uint16_t zeroL;
 	uint16_t zeroH;
@@ -941,7 +775,13 @@ uint16_t mos6502::Addr_ZPI()
 	zeroH = (zeroL + 1) % 256;
 	addr = Read(zeroL) + (Read(zeroH) << 8);
 
-	return addr;
+	return AddrRes { 5, addr };
+}
+
+mos6502::AddrRes mos6502::Addr_AXI()
+{
+	// FIXME Implement addressing mode (abs, x)
+	return AddrRes { 6, 0 };
 }
 
 void mos6502::Reset()
@@ -1028,6 +868,7 @@ void mos6502::Run(
 	uint64_t& cycleCount,
 	CycleMethod cycleMethod
 ) {
+	uint8_t cyclesTaken;
 	uint8_t opcode;
 	Instr instr;
 
@@ -1077,19 +918,19 @@ void mos6502::Run(
 		instr = InstrTable[opcode];
 
 		// execute
-		Exec(instr);
+		cyclesTaken = Exec(instr);
+		cycleCount += cyclesTaken;
 		if(illegalOpcode) {
 			illegalOpcodeSrc = opcode;
 		}
-		cycleCount += instr.cycles;
 		cyclesRemaining -=
-			(cycleMethod == CYCLE_COUNT )       ? instr.cycles
+			(cycleMethod == CYCLE_COUNT )       ? cyclesTaken
 			/* cycleMethod == INST_COUNT */   : 1;
 		if(irq_timer > 0) {
-			if(irq_timer < instr.cycles) {
+			if(irq_timer < cyclesTaken) {
 				irq_timer = 0;
 			} else {
-				irq_timer -= instr.cycles;
+				irq_timer -= cyclesTaken;
 			}
 			if(irq_timer == 0) {
 				if((irq_gate == NULL) || (*irq_gate)) {
@@ -1101,19 +942,19 @@ void mos6502::Run(
 	}
 }
 
-void mos6502::Exec(Instr i)
+uint8_t mos6502::Exec(Instr i)
 {
-	uint16_t src = (this->*i.addr)();
-	(this->*i.code)(src);
+	auto [ cycles, src ] = (this->*i.addr)();
+	return cycles + (this->*i.code)(src);
 }
 
-void mos6502::Op_ILLEGAL(uint16_t src)
+uint8_t mos6502::Op_ILLEGAL(uint16_t src)
 {
 	illegalOpcode = true;
+	return 0;
 }
 
-
-void mos6502::Op_ADC(uint16_t src)
+uint8_t mos6502::Op_ADC(uint16_t src)
 {
 	uint8_t m = Read(src);
 	unsigned int tmp = m + A + (IF_CARRY() ? 1 : 0);
@@ -1137,23 +978,25 @@ void mos6502::Op_ADC(uint16_t src)
 	}
 
 	A = tmp & 0xFF;
-	return;
+
+	// Takes an additional cycle if operating in decimal mode
+	return IF_DECIMAL() ? 1 : 0;
 }
 
 
 
-void mos6502::Op_AND(uint16_t src)
+uint8_t mos6502::Op_AND(uint16_t src)
 {
 	uint8_t m = Read(src);
 	uint8_t res = m & A;
 	SET_NEGATIVE(res & 0x80);
 	SET_ZERO(!res);
 	A = res;
-	return;
+	return 0;
 }
 
 
-void mos6502::Op_ASL(uint16_t src)
+uint8_t mos6502::Op_ASL(uint16_t src)
 {
 	uint8_t m = Read(src);
 	SET_CARRY(m & 0x80);
@@ -1162,10 +1005,10 @@ void mos6502::Op_ASL(uint16_t src)
 	SET_NEGATIVE(m & 0x80);
 	SET_ZERO(!m);
 	Write(src, m);
-	return;
+	return 2;
 }
 
-void mos6502::Op_ASL_ACC(uint16_t src)
+uint8_t mos6502::Op_ASL_ACC(uint16_t src)
 {
 	uint8_t m = A;
 	SET_CARRY(m & 0x80);
@@ -1174,75 +1017,82 @@ void mos6502::Op_ASL_ACC(uint16_t src)
 	SET_NEGATIVE(m & 0x80);
 	SET_ZERO(!m);
 	A = m;
-	return;
+	return 0;
 }
 
-void mos6502::Op_BCC(uint16_t src)
+uint8_t mos6502::Op_BCC(uint16_t src)
 {
 	if (!IF_CARRY())
 	{
 		pc = src;
+		return 1;
 	}
-	return;
+
+	return 0;
 }
 
 
-void mos6502::Op_BCS(uint16_t src)
+uint8_t mos6502::Op_BCS(uint16_t src)
 {
 	if (IF_CARRY())
 	{
 		pc = src;
+		return 1;
 	}
-	return;
+	return 0;
 }
 
-void mos6502::Op_BEQ(uint16_t src)
+uint8_t mos6502::Op_BEQ(uint16_t src)
 {
 	if (IF_ZERO())
 	{
 		pc = src;
+		return 1;
 	}
-	return;
+	return 0;
 }
 
-void mos6502::Op_BIT(uint16_t src)
+uint8_t mos6502::Op_BIT(uint16_t src)
 {
 	uint8_t m = Read(src);
 	uint8_t res = m & A;
 	SET_NEGATIVE(res & 0x80);
 	status = (status & 0x3F) | (uint8_t)(m & 0xC0);
 	SET_ZERO(!res);
-	return;
+	return 0;
 }
 
-void mos6502::Op_BMI(uint16_t src)
+uint8_t mos6502::Op_BMI(uint16_t src)
 {
 	if (IF_NEGATIVE())
 	{
 		pc = src;
+		return 1;
 	}
-	return;
+	return 0;
 }
 
-void mos6502::Op_BNE(uint16_t src)
+uint8_t mos6502::Op_BNE(uint16_t src)
 {
 	if (!IF_ZERO())
 	{
 		pc = src;
+		return 1;
 	}
-	return;
+	return 0;
 }
 
-void mos6502::Op_BPL(uint16_t src)
+uint8_t mos6502::Op_BPL(uint16_t src)
 {
 	if (!IF_NEGATIVE())
 	{
 		pc = src;
+		return 1;
 	}
-	return;
+	return 0;
 }
 
-void mos6502::Op_BRK(uint16_t src)
+uint8_t mos6502::Op_BRK(uint16_t src)
 {
 	pc++;
 	StackPush((pc >> 8) & 0xFF);
@@ -1250,212 +1100,233 @@ void mos6502::Op_BRK(uint16_t src)
 	StackPush(status | BREAK);
 	SET_INTERRUPT(1);
 	pc = (Read(irqVectorH) << 8) + Read(irqVectorL);
-	return;
+	
+	return 7;
 }
 
-void mos6502::Op_WAI(uint16_t src)
+uint8_t mos6502::Op_WAI(uint16_t src)
 {
 	waiting = true;
+
+	return 3;
 }
 
-void mos6502::Op_STP(uint16_t src)
+uint8_t mos6502::Op_STP(uint16_t src)
 {
 	illegalOpcode = true;
 	Stopped();
+
+	return 3;
 }
 
-void mos6502::Op_BVC(uint16_t src)
+uint8_t mos6502::Op_BVC(uint16_t src)
 {
 	if (!IF_OVERFLOW())
 	{
 		pc = src;
+
+		return 1;
 	}
-	return;
+	return 0;
 }
 
-void mos6502::Op_BVS(uint16_t src)
+uint8_t mos6502::Op_BVS(uint16_t src)
 {
 	if (IF_OVERFLOW())
 	{
 		pc = src;
+
+		return 1;
 	}
-	return;
+	return 0;
 }
 
-void mos6502::Op_CLC(uint16_t src)
+uint8_t mos6502::Op_CLC(uint16_t src)
 {
 	SET_CARRY(0);
-	return;
+	return 2;
 }
 
-void mos6502::Op_CLD(uint16_t src)
+uint8_t mos6502::Op_CLD(uint16_t src)
 {
 	SET_DECIMAL(0);
-	return;
+	return 2;
 }
 
-void mos6502::Op_CLI(uint16_t src)
+uint8_t mos6502::Op_CLI(uint16_t src)
 {
 	SET_INTERRUPT(0);
-	return;
+	return 2;
 }
 
-void mos6502::Op_CLV(uint16_t src)
+uint8_t mos6502::Op_CLV(uint16_t src)
 {
 	SET_OVERFLOW(0);
-	return;
+	return 2;
 }
 
-void mos6502::Op_CMP(uint16_t src)
+uint8_t mos6502::Op_CMP(uint16_t src)
 {
 	unsigned int tmp = A - Read(src);
 	SET_CARRY(tmp < 0x100);
 	SET_NEGATIVE(tmp & 0x80);
 	SET_ZERO(!(tmp & 0xFF));
-	return;
+	return 0;
 }
 
-void mos6502::Op_CPX(uint16_t src)
+uint8_t mos6502::Op_CPX(uint16_t src)
 {
 	unsigned int tmp = X - Read(src);
 	SET_CARRY(tmp < 0x100);
 	SET_NEGATIVE(tmp & 0x80);
 	SET_ZERO(!(tmp & 0xFF));
-	return;
+	return 0;
 }
 
-void mos6502::Op_CPY(uint16_t src)
+uint8_t mos6502::Op_CPY(uint16_t src)
 {
 	unsigned int tmp = Y - Read(src);
 	SET_CARRY(tmp < 0x100);
 	SET_NEGATIVE(tmp & 0x80);
 	SET_ZERO(!(tmp & 0xFF));
-	return;
+	return 0;
 }
 
-void mos6502::Op_DEC(uint16_t src)
+uint8_t mos6502::Op_DEC(uint16_t src)
 {
 	uint8_t m = Read(src);
 	m = (m - 1) % 256;
 	SET_NEGATIVE(m & 0x80);
 	SET_ZERO(!m);
 	Write(src, m);
-	return;
+	return 2;
 }
 
-void mos6502::Op_DEC_ACC(uint16_t src)
+uint8_t mos6502::Op_DEC_ACC(uint16_t src)
 {
 	uint8_t m = A;
 	m = (m - 1) % 256;
 	SET_NEGATIVE(m & 0x80);
 	SET_ZERO(!m);
 	A = m;
-	return;
+	return 0;
 }
 
-void mos6502::Op_DEX(uint16_t src)
+uint8_t mos6502::Op_DEX(uint16_t src)
 {
 	uint8_t m = X;
 	m = (m - 1) % 256;
 	SET_NEGATIVE(m & 0x80);
 	SET_ZERO(!m);
 	X = m;
-	return;
+	return 2;
 }
 
-void mos6502::Op_DEY(uint16_t src)
+uint8_t mos6502::Op_DEY(uint16_t src)
 {
 	uint8_t m = Y;
 	m = (m - 1) % 256;
 	SET_NEGATIVE(m & 0x80);
 	SET_ZERO(!m);
 	Y = m;
-	return;
+	return 2;
 }
 
-void mos6502::Op_EOR(uint16_t src)
+uint8_t mos6502::Op_EOR(uint16_t src)
 {
 	uint8_t m = Read(src);
 	m = A ^ m;
 	SET_NEGATIVE(m & 0x80);
 	SET_ZERO(!m);
 	A = m;
+	return 0;
 }
 
-void mos6502::Op_INC(uint16_t src)
+uint8_t mos6502::Op_INC(uint16_t src)
 {
 	uint8_t m = Read(src);
 	m = (m + 1) % 256;
 	SET_NEGATIVE(m & 0x80);
 	SET_ZERO(!m);
 	Write(src, m);
+	return 2;
 }
 
-void mos6502::Op_INC_ACC(uint16_t src)
+uint8_t mos6502::Op_INC_ACC(uint16_t src)
 {
 	uint8_t m = A;
 	m = (m + 1) % 256;
 	SET_NEGATIVE(m & 0x80);
 	SET_ZERO(!m);
 	A = m;
+	return 0;
 }
 
-void mos6502::Op_INX(uint16_t src)
+uint8_t mos6502::Op_INX(uint16_t src)
 {
 	uint8_t m = X;
 	m = (m + 1) % 256;
 	SET_NEGATIVE(m & 0x80);
 	SET_ZERO(!m);
 	X = m;
+	return 2;
 }
 
-void mos6502::Op_INY(uint16_t src)
+uint8_t mos6502::Op_INY(uint16_t src)
 {
 	uint8_t m = Y;
 	m = (m + 1) % 256;
 	SET_NEGATIVE(m & 0x80);
 	SET_ZERO(!m);
 	Y = m;
+	return 2;
 }
 
-void mos6502::Op_JMP(uint16_t src)
+// FIXME JMP should take one *less* cycle if in ABS mode
+uint8_t mos6502::Op_JMP(uint16_t src)
 {
 	pc = src;
+
+	return 0;
 }
 
-void mos6502::Op_JSR(uint16_t src)
+uint8_t mos6502::Op_JSR(uint16_t src)
 {
 	pc--;
 	StackPush((pc >> 8) & 0xFF);
 	StackPush(pc & 0xFF);
 	pc = src;
+	return 2;
 }
 
-void mos6502::Op_LDA(uint16_t src)
+uint8_t mos6502::Op_LDA(uint16_t src)
 {
 	uint8_t m = Read(src);
 	SET_NEGATIVE(m & 0x80);
 	SET_ZERO(!m);
 	A = m;
+	return 0;
 }
 
-void mos6502::Op_LDX(uint16_t src)
+uint8_t mos6502::Op_LDX(uint16_t src)
 {
 	uint8_t m = Read(src);
 	SET_NEGATIVE(m & 0x80);
 	SET_ZERO(!m);
 	X = m;
+	return 0;
 }
 
-void mos6502::Op_LDY(uint16_t src)
+uint8_t mos6502::Op_LDY(uint16_t src)
 {
 	uint8_t m = Read(src);
 	SET_NEGATIVE(m & 0x80);
 	SET_ZERO(!m);
 	Y = m;
+	return 0;
 }
 
-void mos6502::Op_LSR(uint16_t src)
+uint8_t mos6502::Op_LSR(uint16_t src)
 {
 	uint8_t m = Read(src);
 	SET_CARRY(m & 0x01);
@@ -1463,9 +1334,10 @@ void mos6502::Op_LSR(uint16_t src)
 	SET_NEGATIVE(0);
 	SET_ZERO(!m);
 	Write(src, m);
+	return 2;
 }
 
-void mos6502::Op_LSR_ACC(uint16_t src)
+uint8_t mos6502::Op_LSR_ACC(uint16_t src)
 {
 	uint8_t m = A;
 	SET_CARRY(m & 0x01);
@@ -1473,78 +1345,80 @@ void mos6502::Op_LSR_ACC(uint16_t src)
 	SET_NEGATIVE(0);
 	SET_ZERO(!m);
 	A = m;
+	return 0;
 }
 
-void mos6502::Op_NOP(uint16_t src)
+uint8_t mos6502::Op_NOP(uint16_t src)
 {
-	return;
+	return 2;
 }
 
-void mos6502::Op_ORA(uint16_t src)
+uint8_t mos6502::Op_ORA(uint16_t src)
 {
 	uint8_t m = Read(src);
 	m = A | m;
 	SET_NEGATIVE(m & 0x80);
 	SET_ZERO(!m);
 	A = m;
+	return 0;
 }
 
-void mos6502::Op_PHA(uint16_t src)
+uint8_t mos6502::Op_PHA(uint16_t src)
 {
 	StackPush(A);
-	return;
+	return 3;
 }
 
-void mos6502::Op_PHP(uint16_t src)
+uint8_t mos6502::Op_PHP(uint16_t src)
 {
 	StackPush(status | BREAK);
-	return;
+	return 3;
 }
 
-void mos6502::Op_PHX(uint16_t src)
+uint8_t mos6502::Op_PHX(uint16_t src)
 {
 	StackPush(X);
-	return;
+	return 3;
 }
 
-void mos6502::Op_PHY(uint16_t src)
+uint8_t mos6502::Op_PHY(uint16_t src)
 {
 	StackPush(Y);
-	return;
+	return 3;
 }
 
-void mos6502::Op_PLA(uint16_t src)
+uint8_t mos6502::Op_PLA(uint16_t src)
 {
 	A = StackPop();
 	SET_NEGATIVE(A & 0x80);
 	SET_ZERO(!A);
-	return;
+	return 4;
 }
 
-void mos6502::Op_PLP(uint16_t src)
+uint8_t mos6502::Op_PLP(uint16_t src)
 {
 	status = StackPop();
 	SET_CONSTANT(1);
-	return;
+	return 4;
 }
 
-void mos6502::Op_PLX(uint16_t src)
+uint8_t mos6502::Op_PLX(uint16_t src)
 {
 	X = StackPop();
 	SET_NEGATIVE(X & 0x80);
 	SET_ZERO(!X);
-	return;
+	return 4;
 }
 
-void mos6502::Op_PLY(uint16_t src)
+uint8_t mos6502::Op_PLY(uint16_t src)
 {
 	Y = StackPop();
 	SET_NEGATIVE(Y & 0x80);
 	SET_ZERO(!Y);
-	return;
+	return 4;
 }
 
-void mos6502::Op_ROL(uint16_t src)
+uint8_t mos6502::Op_ROL(uint16_t src)
 {
 	uint16_t m = Read(src);
 	m <<= 1;
@@ -1554,10 +1428,10 @@ void mos6502::Op_ROL(uint16_t src)
 	SET_NEGATIVE(m & 0x80);
 	SET_ZERO(!m);
 	Write(src, m);
-	return;
+	return 2;
 }
 
-void mos6502::Op_ROL_ACC(uint16_t src)
+uint8_t mos6502::Op_ROL_ACC(uint16_t src)
 {
 	uint16_t m = A;
 	m <<= 1;
@@ -1567,10 +1441,10 @@ void mos6502::Op_ROL_ACC(uint16_t src)
 	SET_NEGATIVE(m & 0x80);
 	SET_ZERO(!m);
 	A = m;
-	return;
+	return 0;
 }
 
-void mos6502::Op_ROR(uint16_t src)
+uint8_t mos6502::Op_ROR(uint16_t src)
 {
 	uint16_t m = Read(src);
 	if (IF_CARRY()) m |= 0x100;
@@ -1580,10 +1454,10 @@ void mos6502::Op_ROR(uint16_t src)
 	SET_NEGATIVE(m & 0x80);
 	SET_ZERO(!m);
 	Write(src, m);
-	return;
+	return 2;
 }
 
-void mos6502::Op_ROR_ACC(uint16_t src)
+uint8_t mos6502::Op_ROR_ACC(uint16_t src)
 {
 	uint16_t m = A;
 	if (IF_CARRY()) m |= 0x100;
@@ -1593,10 +1467,10 @@ void mos6502::Op_ROR_ACC(uint16_t src)
 	SET_NEGATIVE(m & 0x80);
 	SET_ZERO(!m);
 	A = m;
-	return;
+	return 0;
 }
 
-void mos6502::Op_RTI(uint16_t src)
+uint8_t mos6502::Op_RTI(uint16_t src)
 {
 	uint8_t lo, hi;
 
@@ -1606,10 +1480,10 @@ void mos6502::Op_RTI(uint16_t src)
 	hi = StackPop();
 
 	pc = (hi << 8) | lo;
-	return;
+	return 6;
 }
 
-void mos6502::Op_RTS(uint16_t src)
+uint8_t mos6502::Op_RTS(uint16_t src)
 {
 	uint8_t lo, hi;
 
@@ -1617,10 +1491,10 @@ void mos6502::Op_RTS(uint16_t src)
 	hi = StackPop();
 
 	pc = ((hi << 8) | lo) + 1;
-	return;
+	return 6;
 }
 
-void mos6502::Op_SBC(uint16_t src)
+uint8_t mos6502::Op_SBC(uint16_t src)
 {
 	uint8_t m = Read(src);
 	unsigned int tmp = A - m - (IF_CARRY() ? 0 : 1);
@@ -1638,120 +1512,127 @@ void mos6502::Op_SBC(uint16_t src)
 	}
 	SET_CARRY(tmp < 0x100);
 	A = (tmp & 0xFF);
-	return;
+
+	// Takes an additional cycle if in decimal mode
+	return IF_DECIMAL() ? 1 : 0;
 }
 
-void mos6502::Op_SEC(uint16_t src)
+uint8_t mos6502::Op_SEC(uint16_t src)
 {
 	SET_CARRY(1);
-	return;
+	return 2;
 }
 
-void mos6502::Op_SED(uint16_t src)
+uint8_t mos6502::Op_SED(uint16_t src)
 {
 	SET_DECIMAL(1);
-	return;
+	return 2;
 }
 
-void mos6502::Op_SEI(uint16_t src)
+uint8_t mos6502::Op_SEI(uint16_t src)
 {
 	SET_INTERRUPT(1);
-	return;
+	return 2;
 }
 
-void mos6502::Op_STA(uint16_t src)
+uint8_t mos6502::Op_STA(uint16_t src)
 {
 	Write(src, A);
-	return;
+	return 0;
 }
 
-void mos6502::Op_STZ(uint16_t src)
+uint8_t mos6502::Op_STZ(uint16_t src)
 {
 	Write(src, 0);
-	return;
+	return 0;
 }
 
-void mos6502::Op_STX(uint16_t src)
+uint8_t mos6502::Op_STX(uint16_t src)
 {
 	Write(src, X);
-	return;
+	return 0;
 }
 
-void mos6502::Op_STY(uint16_t src)
+uint8_t mos6502::Op_STY(uint16_t src)
 {
 	Write(src, Y);
-	return;
+	return 0;
 }
 
-void mos6502::Op_TAX(uint16_t src)
+uint8_t mos6502::Op_TAX(uint16_t src)
 {
 	uint8_t m = A;
 	SET_NEGATIVE(m & 0x80);
 	SET_ZERO(!m);
 	X = m;
-	return;
+	return 2;
 }
 
-void mos6502::Op_TAY(uint16_t src)
+uint8_t mos6502::Op_TAY(uint16_t src)
 {
 	uint8_t m = A;
 	SET_NEGATIVE(m & 0x80);
 	SET_ZERO(!m);
 	Y = m;
-	return;
+	return 2;
 }
 
-void mos6502::Op_TSX(uint16_t src)
+uint8_t mos6502::Op_TSX(uint16_t src)
 {
 	uint8_t m = sp;
 	SET_NEGATIVE(m & 0x80);
 	SET_ZERO(!m);
 	X = m;
-	return;
+	return 2;
 }
 
-void mos6502::Op_TXA(uint16_t src)
+uint8_t mos6502::Op_TXA(uint16_t src)
 {
 	uint8_t m = X;
 	SET_NEGATIVE(m & 0x80);
 	SET_ZERO(!m);
 	A = m;
-	return;
+	return 2;
 }
 
-void mos6502::Op_TXS(uint16_t src)
+uint8_t mos6502::Op_TXS(uint16_t src)
 {
 	sp = X;
-	return;
+	return 2;
 }
 
-void mos6502::Op_TYA(uint16_t src)
+uint8_t mos6502::Op_TYA(uint16_t src)
 {
 	uint8_t m = Y;
 	SET_NEGATIVE(m & 0x80);
 	SET_ZERO(!m);
 	A = m;
-	return;
+	return 2;
 }
 
-void mos6502::Op_BRA(uint16_t src)
+// FIXME this takes an additional cycle if crossing page boundry
+uint8_t mos6502::Op_BRA(uint16_t src)
 {
 	pc = src;
-	return;
+	return 1;
 }
 
-void mos6502::Op_TRB(uint16_t src)
+uint8_t mos6502::Op_TRB(uint16_t src)
 {
 	uint8_t m = Read(src);
 	SET_ZERO(m & A);
 	m = m & ~A;
 	Write(src, m);
+
+	return 2;
 }
 
-void mos6502::Op_TSB(uint16_t src)
+uint8_t mos6502::Op_TSB(uint16_t src)
 {
 	uint8_t m = Read(src);
 	SET_ZERO(m & A);
 	m = m | A;
 	Write(src, m);
+
+	return 2;
 }

--- a/src/mos6502/mos6502.h
+++ b/src/mos6502/mos6502.h
@@ -42,118 +42,122 @@ using namespace std;
 class mos6502
 {
 private:
-	
+	struct AddrRes
+	{
+		uint8_t cycles;
+		uint16_t addr;
+	};
 
-	typedef void (mos6502::*CodeExec)(uint16_t);
-	typedef uint16_t (mos6502::*AddrExec)();
+	typedef uint8_t (mos6502::*CodeExec)(uint16_t);
+	typedef AddrRes (mos6502::*AddrExec)();
 
 	struct Instr
 	{
 		AddrExec addr;
 		CodeExec code;
-		uint8_t cycles;
 	};
 
 	Instr InstrTable[256];
 
-	void Exec(Instr i);
+	uint8_t Exec(Instr i);
 
 	// addressing modes
-	uint16_t Addr_ACC(); // ACCUMULATOR
-	uint16_t Addr_IMM(); // IMMEDIATE
-	uint16_t Addr_ABS(); // ABSOLUTE
-	uint16_t Addr_ZER(); // ZERO PAGE
-	uint16_t Addr_ZEX(); // INDEXED-X ZERO PAGE
-	uint16_t Addr_ZEY(); // INDEXED-Y ZERO PAGE
-	uint16_t Addr_ABX(); // INDEXED-X ABSOLUTE
-	uint16_t Addr_ABY(); // INDEXED-Y ABSOLUTE
-	uint16_t Addr_IMP(); // IMPLIED
-	uint16_t Addr_REL(); // RELATIVE
-	uint16_t Addr_INX(); // INDEXED-X INDIRECT
-	uint16_t Addr_INY(); // INDEXED-Y INDIRECT
-	uint16_t Addr_ABI(); // ABSOLUTE INDIRECT
-	uint16_t Addr_ZPI(); // ZERO PAGE INDIRECT
+	AddrRes Addr_ACC(); // ACCUMULATOR
+	AddrRes Addr_IMM(); // IMMEDIATE
+	AddrRes Addr_ABS(); // ABSOLUTE
+	AddrRes Addr_ZER(); // ZERO PAGE
+	AddrRes Addr_ZEX(); // INDEXED-X ZERO PAGE
+	AddrRes Addr_ZEY(); // INDEXED-Y ZERO PAGE
+	AddrRes Addr_ABX(); // INDEXED-X ABSOLUTE
+	AddrRes Addr_ABY(); // INDEXED-Y ABSOLUTE
+	AddrRes Addr_IMP(); // IMPLIED
+	AddrRes Addr_REL(); // RELATIVE
+	AddrRes Addr_INX(); // INDEXED-X INDIRECT
+	AddrRes Addr_INY(); // INDEXED-Y INDIRECT
+	AddrRes Addr_ABI(); // ABSOLUTE INDIRECT
+	AddrRes Addr_ZPI(); // ZERO PAGE INDIRECT
+	AddrRes Addr_AXI(); // INDEXED-X ABSOLUTE INDIRECT
 
 	// opcodes (grouped as per datasheet)
-	void Op_ADC(uint16_t src);
-	void Op_AND(uint16_t src);
-	void Op_ASL(uint16_t src); 	void Op_ASL_ACC(uint16_t src);
-	void Op_BCC(uint16_t src);
-	void Op_BCS(uint16_t src);
+	uint8_t Op_ADC(uint16_t src);
+	uint8_t Op_AND(uint16_t src);
+	uint8_t Op_ASL(uint16_t src); 	uint8_t Op_ASL_ACC(uint16_t src);
+	uint8_t Op_BCC(uint16_t src);
+	uint8_t Op_BCS(uint16_t src);
 
-	void Op_BEQ(uint16_t src);
-	void Op_BIT(uint16_t src);
-	void Op_BMI(uint16_t src);
-	void Op_BNE(uint16_t src);
-	void Op_BPL(uint16_t src);
+	uint8_t Op_BEQ(uint16_t src);
+	uint8_t Op_BIT(uint16_t src);
+	uint8_t Op_BMI(uint16_t src);
+	uint8_t Op_BNE(uint16_t src);
+	uint8_t Op_BPL(uint16_t src);
 
-	void Op_BRK(uint16_t src);
-	void Op_BVC(uint16_t src);
-	void Op_BVS(uint16_t src);
-	void Op_CLC(uint16_t src);
-	void Op_CLD(uint16_t src);
+	uint8_t Op_BRK(uint16_t src);
+	uint8_t Op_BVC(uint16_t src);
+	uint8_t Op_BVS(uint16_t src);
+	uint8_t Op_CLC(uint16_t src);
+	uint8_t Op_CLD(uint16_t src);
 
-	void Op_CLI(uint16_t src);
-	void Op_CLV(uint16_t src);
-	void Op_CMP(uint16_t src);
-	void Op_CPX(uint16_t src);
-	void Op_CPY(uint16_t src);
+	uint8_t Op_CLI(uint16_t src);
+	uint8_t Op_CLV(uint16_t src);
+	uint8_t Op_CMP(uint16_t src);
+	uint8_t Op_CPX(uint16_t src);
+	uint8_t Op_CPY(uint16_t src);
 
-	void Op_DEC(uint16_t src);	void Op_DEC_ACC(uint16_t src);
-	void Op_DEX(uint16_t src);
-	void Op_DEY(uint16_t src);
-	void Op_EOR(uint16_t src);
-	void Op_INC(uint16_t src);	void Op_INC_ACC(uint16_t src);
+	uint8_t Op_DEC(uint16_t src);	uint8_t Op_DEC_ACC(uint16_t src);
+	uint8_t Op_DEX(uint16_t src);
+	uint8_t Op_DEY(uint16_t src);
+	uint8_t Op_EOR(uint16_t src);
+	uint8_t Op_INC(uint16_t src);	uint8_t Op_INC_ACC(uint16_t src);
 
-	void Op_INX(uint16_t src);
-	void Op_INY(uint16_t src);
-	void Op_JMP(uint16_t src);
-	void Op_JSR(uint16_t src);
-	void Op_LDA(uint16_t src);
+	uint8_t Op_INX(uint16_t src);
+	uint8_t Op_INY(uint16_t src);
+	uint8_t Op_JMP(uint16_t src);
+	uint8_t Op_JSR(uint16_t src);
+	uint8_t Op_LDA(uint16_t src);
 
-	void Op_LDX(uint16_t src);
-	void Op_LDY(uint16_t src);
-	void Op_LSR(uint16_t src); 	void Op_LSR_ACC(uint16_t src);
-	void Op_NOP(uint16_t src);
-	void Op_ORA(uint16_t src);
+	uint8_t Op_LDX(uint16_t src);
+	uint8_t Op_LDY(uint16_t src);
+	uint8_t Op_LSR(uint16_t src); 	uint8_t Op_LSR_ACC(uint16_t src);
+	uint8_t Op_NOP(uint16_t src);
+	uint8_t Op_ORA(uint16_t src);
 
-	void Op_PHA(uint16_t src);
-	void Op_PHP(uint16_t src);
-	void Op_PHX(uint16_t src);
-	void Op_PHY(uint16_t src);
-	void Op_PLA(uint16_t src);
-	void Op_PLP(uint16_t src);
-	void Op_PLX(uint16_t src);
-	void Op_PLY(uint16_t src);
-	void Op_ROL(uint16_t src); 	void Op_ROL_ACC(uint16_t src);
+	uint8_t Op_PHA(uint16_t src);
+	uint8_t Op_PHP(uint16_t src);
+	uint8_t Op_PHX(uint16_t src);
+	uint8_t Op_PHY(uint16_t src);
+	uint8_t Op_PLA(uint16_t src);
+	uint8_t Op_PLP(uint16_t src);
+	uint8_t Op_PLX(uint16_t src);
+	uint8_t Op_PLY(uint16_t src);
+	uint8_t Op_ROL(uint16_t src); 	uint8_t Op_ROL_ACC(uint16_t src);
 
-	void Op_ROR(uint16_t src);	void Op_ROR_ACC(uint16_t src);
-	void Op_RTI(uint16_t src);
-	void Op_RTS(uint16_t src);
-	void Op_SBC(uint16_t src);
-	void Op_SEC(uint16_t src);
-	void Op_SED(uint16_t src);
+	uint8_t Op_ROR(uint16_t src);	uint8_t Op_ROR_ACC(uint16_t src);
+	uint8_t Op_RTI(uint16_t src);
+	uint8_t Op_RTS(uint16_t src);
+	uint8_t Op_SBC(uint16_t src);
+	uint8_t Op_SEC(uint16_t src);
+	uint8_t Op_SED(uint16_t src);
 
-	void Op_SEI(uint16_t src);
-	void Op_STA(uint16_t src);
-	void Op_STZ(uint16_t src);
-	void Op_STX(uint16_t src);
-	void Op_STY(uint16_t src);
-	void Op_TAX(uint16_t src);
+	uint8_t Op_SEI(uint16_t src);
+	uint8_t Op_STA(uint16_t src);
+	uint8_t Op_STZ(uint16_t src);
+	uint8_t Op_STX(uint16_t src);
+	uint8_t Op_STY(uint16_t src);
+	uint8_t Op_TAX(uint16_t src);
 
-	void Op_TAY(uint16_t src);
-	void Op_TSX(uint16_t src);
-	void Op_TXA(uint16_t src);
-	void Op_TXS(uint16_t src);
-	void Op_TYA(uint16_t src);
+	uint8_t Op_TAY(uint16_t src);
+	uint8_t Op_TSX(uint16_t src);
+	uint8_t Op_TXA(uint16_t src);
+	uint8_t Op_TXS(uint16_t src);
+	uint8_t Op_TYA(uint16_t src);
 
-	void Op_WAI(uint16_t src);
-	void Op_STP(uint16_t src);
-	void Op_BRA(uint16_t src);
-	void Op_TRB(uint16_t src);
-	void Op_TSB(uint16_t src);
+	uint8_t Op_WAI(uint16_t src);
+	uint8_t Op_STP(uint16_t src);
+	uint8_t Op_BRA(uint16_t src);
+	uint8_t Op_TRB(uint16_t src);
+	uint8_t Op_TSB(uint16_t src);
 
-	void Op_ILLEGAL(uint16_t src);
+	uint8_t Op_ILLEGAL(uint16_t src);
 
 	// IRQ, reset, NMI vectors
 	static const uint16_t irqVectorH = 0xFFFF;


### PR DESCRIPTION
Implement conditional timing

Each opcode does not always correspond to a given amount of cycles taken. Some examples:
- Branching instructions take an additional cycle if the branch is taken
- Many instructions take additional cycles if page boundaries are crossed

This pr is not accurate in it's current state.  It takes a simplifies model as follows:
- Execute the addressing mode. This takes some amount of cycles
- Execute the code. This takes some amount of cycles
- Return the sum

 In general this works, however some instructions require a bit more care. `STA Indirect,Y` always takes 6 cycles. All other `Indirect, Y` instructions take a base of 5 cycles with an additional cycle if crossing page boundaries. There may be other inconsistencies I haven't found. I'm going to go over the 6502.org pages and that datasheet to make sure everything is in order (you should definitely take a look too if you don't mind lol)