### PR TITLE
Source map parsing

### DIFF
--- a/src/devtools/breakpoints.cpp
+++ b/src/devtools/breakpoints.cpp
@@ -14,7 +14,7 @@ bool Breakpoints::checkBreakpoint(uint16_t address, uint8_t bank) {
     }
     //for some reason it was getting stuck so wait a number of cycles between breakpoint activations
 
-    auto matcher = [address, bank](Breakpoint i) { return (i.address == address) && (!i.bank_set || (i.bank == bank)) && i.enabled && !i.linkFailed; };
+    auto matcher = [address, bank](Breakpoint i) { return (i.address == address) && (!i.bank_set || (i.bank == bank) || (((i.bank & 127) == 127) && address >= 0xC000   )) && i.enabled && !i.linkFailed; };
     auto it = std::find_if(begin(breakpoints), end(breakpoints), matcher);
 
     if(it != std::end(breakpoints)) {

--- a/src/devtools/source_map.cpp
+++ b/src/devtools/source_map.cpp
@@ -1,0 +1,224 @@
+#include "source_map.h"
+#include <iostream>
+#include <fstream>
+#include <sstream>
+#include <unordered_map>
+#include <algorithm>
+
+SourceMap* SourceMap::singleton = nullptr;
+
+// Helper function to parse a line into type name and key-value pairs
+bool parseLine(const std::string& line, std::string& typeName, std::unordered_map<std::string, std::string>& keyValuePairs) {
+    std::istringstream lineStream(line);
+
+    // Get the type name before the tab character
+    if (!std::getline(lineStream, typeName, '\t')) {
+        return false;
+    }
+
+    std::string keyValuePart;
+    // Get the key-value pairs after the tab character
+    if (std::getline(lineStream, keyValuePart)) {
+        std::istringstream kvStream(keyValuePart);
+        std::string kvPair;
+
+        // Parse each key-value pair separated by commas
+        while (std::getline(kvStream, kvPair, ',')) {
+            std::string key, value;
+            std::istringstream kvPairStream(kvPair);
+            
+            // Split each pair into key and value based on '='
+            if (std::getline(kvPairStream, key, '=') && std::getline(kvPairStream, value)) {
+                keyValuePairs[key] = value;
+            } else {
+                return false;
+            }
+        }
+    } else {
+        return false;
+    }
+
+    return true;
+}
+
+bool compareSMLines(const SourceMapLine &a, const SourceMapLine &b) {
+    return a.id < b.id;
+}
+
+bool compareSMFiles(const SourceMapFile &a, const SourceMapFile &b) {
+    return a.id < b.id;
+}
+
+bool compareSMSegments(const SourceMapSegment &a, const SourceMapSegment &b) {
+    return a.id < b.id;
+}
+
+bool compareSMSpans(const SourceMapSpan &a, const SourceMapSpan &b) {
+    return a.id < b.id;
+}
+
+SourceMap::SourceMap(std::string& dbg_file_path) {
+    std::ifstream dbgfile(dbg_file_path);
+    if(!dbgfile.is_open()) {
+        throw std::runtime_error("Unable to open " + dbg_file_path);
+    }
+
+    std::string line;
+
+    std::unordered_map<std::string, std::vector<std::unordered_map<std::string, std::string>>> dbg_table;
+
+    while (std::getline(dbgfile, line)) {
+        std::string typeName;
+        std::unordered_map<std::string, std::string> keyValuePairs;
+
+        // Parse type name and key-value pairs
+        if (parseLine(line, typeName, keyValuePairs)) {
+            dbg_table[typeName].emplace_back(keyValuePairs);
+        }
+    }
+
+    for(auto& line_map : dbg_table["line"]) {
+        SourceMapLine entry;
+        entry.id = std::stoi(line_map["id"]);
+        entry.file = std::stoi(line_map["file"]);
+        entry.line = std::stoi(line_map["line"]);
+        entry.has_span = line_map.contains("span");
+        if(entry.has_span) {
+            entry.span = std::stoi(line_map["span"]);
+        }
+        entry.has_type = line_map.contains("type");
+        if(entry.has_type) {
+            entry.type = std::stoi(line_map["type"]);
+        }
+        lines.emplace_back(entry);
+    }
+
+    for(auto& line_map : dbg_table["file"]) {
+        SourceMapFile entry;
+        entry.id = std::stoi(line_map["id"]);
+        entry.contents_cached = false;
+        entry.contents = nullptr;
+        entry.name = line_map["name"];
+        files.emplace_back(entry);
+    }
+
+    for(auto& line_map : dbg_table["span"]) {
+        SourceMapSpan entry;
+        entry.id = std::stoi(line_map["id"]);
+        entry.segment = std::stoi(line_map["seg"]);
+        entry.size = std::stoi(line_map["size"]);
+        entry.start = std::stoi(line_map["start"]);
+        entry.has_type = line_map.contains("type");
+        if(entry.has_type) {
+            entry.type = std::stoi(line_map["type"]);
+        }
+        spans.emplace_back(entry);
+    }
+
+    for(auto& line_map : dbg_table["seg"]) {
+        SourceMapSegment entry;
+        entry.id = std::stoi(line_map["id"]);
+        entry.name = line_map["name"];
+        entry.size = std::stoi(line_map["size"], nullptr, 16);
+        entry.start = std::stoi(line_map["start"], nullptr, 16);
+        entry.has_bank = line_map.contains("bank");
+        if(entry.has_bank) {
+            entry.bank = std::stoi(line_map["bank"]);
+        }
+        segments.emplace_back(entry);
+    }
+
+    std::sort(lines.begin(), lines.end(), compareSMLines);
+    std::sort(files.begin(), files.end(), compareSMFiles);
+    std::sort(segments.begin(), segments.end(), compareSMSegments);
+    std::sort(spans.begin(), spans.end(), compareSMSpans);
+}
+
+SourceMapSearchResult SourceMap::Search(uint16_t addr, uint8_t bank) {
+
+    SourceMapSearchResult result = {
+        false, nullptr, nullptr, 0
+    };
+
+    bank &= 127;
+    if(addr < 0x8000) {
+        std::cout << "WARNING: mapping ramfuncs isn't supported yet but I'll try my best...\n";
+    }
+
+    if(addr >= 0xC000) {
+        bank = 127;
+    }
+
+    int seg_idx = -1;
+    uint16_t rel_addr = 0;
+
+    for(auto& seg: segments) {
+        if(seg.has_bank && ((seg.bank & 127) == bank)) {
+            if((addr >= seg.start) && ((addr - seg.start) < seg.size)) {
+                seg_idx = seg.id;
+                rel_addr = addr - seg.start;
+                break;
+            }
+        }
+    }
+    if(seg_idx == -1) {
+        result.debug = 1;
+        return result;
+    }
+
+    int spans_found = 0;
+#define MAX_MATCHING_SPANS 3
+    int matching_spans[3];
+    for(auto& span: spans) {
+        if(span.segment == seg_idx) {
+            if((rel_addr >= span.start) && ((rel_addr - span.start) < span.size)) {
+                    matching_spans[spans_found++] = span.id;
+                    if(spans_found == MAX_MATCHING_SPANS)
+                        break;
+            }
+        }
+    }
+
+    if(spans_found == 0) {
+        result.debug = 2;
+        return result;
+    }
+
+
+    int line_idx = -1;
+    int first_found_line = -1;
+    result.debug = seg_idx;
+    for(int i = 0; i < spans_found; ++i) {
+            for(auto& line: lines) {
+            if(line.has_span && (line.span == matching_spans[i])) {
+                if(first_found_line == -1)
+                    first_found_line = line.id;
+
+                /* Find the C version, presumably meaning type 1 */
+                if(line.has_type && (line.type == 1)) {
+                    line_idx = line.id;
+                }
+            }
+        }
+    }
+
+    if(first_found_line == -1) {
+        return result;
+    }
+
+    if(line_idx == -1) {
+        line_idx = first_found_line;
+    }
+
+    result.line = &lines[line_idx];
+    if((result.line == nullptr) || (result.line->id != line_idx)) {
+        throw std::runtime_error("line at index doesn't match ID!");
+    }
+    result.file = &files[result.line->file];
+    if((result.file == nullptr) || (result.file->id != result.line->file)) {
+        throw std::runtime_error("file at index doesn't match ID!");
+    }
+    result.found = true;
+
+    return result;
+}

--- a/src/devtools/source_map.h
+++ b/src/devtools/source_map.h
@@ -16,7 +16,7 @@ typedef struct SourceMapFile{
     unsigned int id;
     std::string name;
     bool contents_cached;
-    char* contents;
+    std::vector<std::string> contents;
 } SourceMapFile;
 
 typedef struct SourceSpan {
@@ -51,8 +51,9 @@ private:
     std::vector<SourceMapSpan> spans;
     std::vector<SourceMapSegment> segments;
 public:
+    std::string project_root;
     static SourceMap* singleton;
-
+    void GetFileContent(SourceMapFile &sourceMapFile);
     SourceMap(std::string& dbg_file_path);
     SourceMapSearchResult Search(uint16_t addr, uint8_t bank);
 };

--- a/src/devtools/source_map.h
+++ b/src/devtools/source_map.h
@@ -1,0 +1,58 @@
+#pragma once
+#include <vector>
+#include <string>
+
+typedef struct SourceMapLine {
+    unsigned int id;
+    unsigned int file;
+    unsigned int line;
+    bool has_type;
+    unsigned int type;
+    bool has_span;
+    unsigned int span;
+} SourceMapLine;
+
+typedef struct SourceMapFile{
+    unsigned int id;
+    std::string name;
+    bool contents_cached;
+    char* contents;
+} SourceMapFile;
+
+typedef struct SourceSpan {
+    unsigned int id;
+    unsigned int segment;
+    unsigned int start;
+    unsigned int size;
+    bool has_type;
+    unsigned int type;
+} SourceMapSpan;
+
+typedef struct SourceMapSegment {
+    unsigned int id;
+    std::string name;
+    unsigned int start;
+    unsigned int size;
+    bool has_bank;
+    unsigned int bank;
+} SourceMapSegment;
+
+typedef struct SourceMapSearchResult {
+    bool found;
+    SourceMapFile *file;
+    SourceMapLine *line;
+    unsigned int debug;
+} SourceMapSearchResult;
+
+class SourceMap {
+private:
+    std::vector<SourceMapLine> lines;
+    std::vector<SourceMapFile> files;
+    std::vector<SourceMapSpan> spans;
+    std::vector<SourceMapSegment> segments;
+public:
+    static SourceMap* singleton;
+
+    SourceMap(std::string& dbg_file_path);
+    SourceMapSearchResult Search(uint16_t addr, uint8_t bank);
+};

--- a/src/devtools/source_map.h
+++ b/src/devtools/source_map.h
@@ -44,16 +44,25 @@ typedef struct SourceMapSearchResult {
     unsigned int debug;
 } SourceMapSearchResult;
 
+typedef struct SourceMapReverseSearchResult {
+    bool found;
+    uint16_t address;
+    uint8_t bank;
+} SourceMapReverseSearchResult;
+
 class SourceMap {
 private:
     std::vector<SourceMapLine> lines;
     std::vector<SourceMapFile> files;
     std::vector<SourceMapSpan> spans;
     std::vector<SourceMapSegment> segments;
+    std::vector<std::string> file_names;
 public:
     std::string project_root;
     static SourceMap* singleton;
     void GetFileContent(SourceMapFile &sourceMapFile);
     SourceMap(std::string& dbg_file_path);
     SourceMapSearchResult Search(uint16_t addr, uint8_t bank);
+    SourceMapReverseSearchResult ReverseSearch(std::string name, int line);
+    std::vector<std::string>& GetFileNames();
 };

--- a/src/devtools/stepping_window.cpp
+++ b/src/devtools/stepping_window.cpp
@@ -3,6 +3,7 @@
 #include "breakpoints.h"
 #include "disassembler.h"
 #include "imgui-combo-filter.h"
+#include "source_map.h"
 #include <string>
 
 ImVec2 SteppingWindow::Render() {
@@ -130,7 +131,20 @@ ImVec2 SteppingWindow::Render() {
     ImGui::Text("Status: %02x Stack: %02x PC: %04x", cpu->status, cpu->sp, cpu->pc);
     ImGui::Text("Cycles Since Boot: %lu", timekeeper.totalCyclesCount);
     ImGui::NewLine();
+
     if(timekeeper.clock_mode == CLOCKMODE_STOPPED) {
+
+        if(SourceMap::singleton) {
+            SourceMapSearchResult res = SourceMap::singleton->Search(cpu->pc, cartridgestate.bank_mask);
+            if(res.found) {
+                ImGui::Text("%s:%d", res.file->name.c_str(), res.line->line);
+            } else {
+                ImGui::Text("Couldn't find source for %04x/%02x, debug num is %d", cpu->pc, cartridgestate.bank_mask, res.debug);
+            }
+        } else {
+            ImGui::Text("No source map loaded");
+        }
+
         for(auto& line : Disassembler::GetLastDecode()) {
             if(line.isLabel) {
                 ImGui::Text("%s", line.disassembledLine.c_str());

--- a/src/devtools/stepping_window.h
+++ b/src/devtools/stepping_window.h
@@ -4,6 +4,7 @@
 #include <functional>
 #include "../mos6502/mos6502.h"
 #include "../game_config.h"
+#include "../system_state.h"
 
 class SteppingWindow : public DebugWindow {
 private:
@@ -11,8 +12,18 @@ private:
     MemoryMap*& memorymap;
     mos6502* cpu;
     GameConfig& gameconfig;
+    CartridgeState& cartridgestate;
 protected:
     ImVec2 Render();
 public:
-    SteppingWindow(Timekeeper& timekeeper, MemoryMap*& memorymap, mos6502* cpu, GameConfig& gameconfig) : timekeeper(timekeeper), memorymap(memorymap), cpu(cpu), gameconfig(gameconfig){};
+    SteppingWindow(Timekeeper& timekeeper,
+        MemoryMap*& memorymap,
+        mos6502* cpu,
+        GameConfig& gameconfig,
+        CartridgeState& cartridgestate) : 
+        timekeeper(timekeeper),
+        memorymap(memorymap),
+        cpu(cpu),
+        gameconfig(gameconfig),
+        cartridgestate(cartridgestate){};
 };

--- a/src/gte.cpp
+++ b/src/gte.cpp
@@ -31,6 +31,7 @@
 
 #include "devtools/memory_map.h"
 #include "devtools/breakpoints.h"
+#include "devtools/source_map.h"
 
 #include "ui/ui_utils.h"
 #include "devtools/profiler.h"
@@ -598,15 +599,24 @@ extern "C" {
 
 		gameconfig = new GameConfig(nvramPath.string().c_str());
 
-		std::filesystem::path defaultMapFilePath = filepath.parent_path().append("../build/out.map");
+		std::filesystem::path defaultMemMapFilePath = filepath.parent_path().append("../build/out.map");
+		std::filesystem::path defaultSourceMapFilePath = filepath.parent_path().append("../build/sourcemap.dbg");
 
-		if(std::filesystem::exists(defaultMapFilePath)) {
-			printf("found default memory map file location %s\n", defaultMapFilePath.c_str());
-			loadedMemoryMap = new MemoryMap(defaultMapFilePath.string());
+		if(std::filesystem::exists(defaultMemMapFilePath)) {
+			printf("found default memory map file location %s\n", defaultMemMapFilePath.c_str());
+			loadedMemoryMap = new MemoryMap(defaultMemMapFilePath.string());
 			Breakpoints::linkBreakpoints(*loadedMemoryMap);
 		} else {
 			loadedMemoryMap = new MemoryMap();
-			printf("default memory map file %s not found\n", defaultMapFilePath.c_str());
+			printf("default memory map file %s not found\n", defaultMemMapFilePath.c_str());
+		}
+
+		if(std::filesystem::exists(defaultSourceMapFilePath)) {
+			printf("found default source map file location %s\n", defaultSourceMapFilePath.c_str());
+			std::string sourceMapPathString = defaultSourceMapFilePath.string();
+			SourceMap::singleton = new SourceMap(sourceMapPathString);
+		} else {
+			printf("default source map file %s not found\n", defaultSourceMapFilePath.c_str());
 		}
 
 		printf("loading %s\n", filename);
@@ -732,7 +742,7 @@ void toggleVRAMWindow() {
 
 void toggleSteppingWindow() {
 	if(!toolTypeIsOpen<SteppingWindow>()) {
-		toolWindows.push_back(new SteppingWindow(timekeeper, loadedMemoryMap, cpu_core, *gameconfig));
+		toolWindows.push_back(new SteppingWindow(timekeeper, loadedMemoryMap, cpu_core, *gameconfig, cartridge_state));
 	} else {
 		closeToolByType<SteppingWindow>();
 	}


### PR DESCRIPTION
https://github.com/clydeshaffer/GameTankEmulator/issues/33

Parse the dbgfile from ld65 to use as a source map

Currently requires the "bank" attribute printed in the dbgfile from cc65 fork: https://github.com/clydeshaffer/cc65

Like the memory map feature it assumes/requires a the directory structure and tooling of a gametank_sdk project