### PR TITLE
Conditionally add extra cycles

### DIFF
--- a/src/mos6502/mos6502.cpp
+++ b/src/mos6502/mos6502.cpp
@@ -885,26 +885,38 @@ uint16_t mos6502::Addr_ZEY()
 uint16_t mos6502::Addr_ABX()
 {
 	uint16_t addr;
+	uint16_t addrBase;
 	uint16_t addrL;
 	uint16_t addrH;
 
 	addrL = Read(pc++);
 	addrH = Read(pc++);
 
-	addr = addrL + (addrH << 8) + X;
+	addrBase = addrL + (addrH << 8);
+	addr = addrBase + X;
+
+	// An extra cycle is required if a page boundary is crossed
+	if (addrBase & 0xFF00 != addr & 0xFF00) opExtraCycles += 1;
+
 	return addr;
 }
 
 uint16_t mos6502::Addr_ABY()
 {
 	uint16_t addr;
+	uint16_t addrBase;
 	uint16_t addrL;
 	uint16_t addrH;
 
 	addrL = Read(pc++);
 	addrH = Read(pc++);
 
-	addr = addrL + (addrH << 8) + Y;
+	addrBase = addrL + (addrH << 8);
+	addr = addrBase + Y;
+
+	// An extra cycle is required if a page boundary is crossed
+	if (addrBase & 0xFF00 != addr & 0xFF00) opExtraCycles += 1;
+
 	return addr;
 }
 
@@ -927,10 +939,15 @@ uint16_t mos6502::Addr_INY()
 	uint16_t zeroL;
 	uint16_t zeroH;
 	uint16_t addr;
+	uint16_t addrBase;
 
 	zeroL = Read(pc++);
 	zeroH = (zeroL + 1) % 256;
-	addr = Read(zeroL) + (Read(zeroH) << 8) + Y;
+	addrBase = Read(zeroL) + (Read(zeroH) << 8);
+	addr = addrBase + Y;
+
+	// An extra cycle is required if a page boundary is crossed
+	if (addrBase & 0xFF00 != addr & 0xFF00) opExtraCycles += 1;
 
 	return addr;
 }

--- a/src/mos6502/mos6502.cpp
+++ b/src/mos6502/mos6502.cpp
@@ -1123,9 +1123,13 @@ void mos6502::Op_ADC(uint16_t src)
 {
 	uint8_t m = Read(src);
 	unsigned int tmp = m + A + (IF_CARRY() ? 1 : 0);
+
 	SET_ZERO(!(tmp & 0xFF));
 	if (IF_DECIMAL())
 	{
+		// An extra cycle is required if in decimal mode
+		opExtraCycles = 1;
+
 		if (((A & 0xF) + (m & 0xF) + (IF_CARRY() ? 1 : 0)) > 9) tmp += 6;
 		SET_NEGATIVE(tmp & 0x80);
 		SET_OVERFLOW(!((A ^ m) & 0x80) && ((A ^ tmp) & 0x80));
@@ -1648,6 +1652,9 @@ void mos6502::Op_SBC(uint16_t src)
 
 	if (IF_DECIMAL())
 	{
+		// An extra cycle is required if in decimal mode
+		opExtraCycles = 1;
+
 		if ( ((A & 0x0F) - (IF_CARRY() ? 0 : 1)) < (m & 0x0F)) tmp -= 6;
 		if (tmp > 0x99)
 		{

--- a/src/mos6502/mos6502.cpp
+++ b/src/mos6502/mos6502.cpp
@@ -1128,7 +1128,7 @@ void mos6502::Op_ADC(uint16_t src)
 	if (IF_DECIMAL())
 	{
 		// An extra cycle is required if in decimal mode
-		opExtraCycles = 1;
+		opExtraCycles += 1;
 
 		if (((A & 0xF) + (m & 0xF) + (IF_CARRY() ? 1 : 0)) > 9) tmp += 6;
 		SET_NEGATIVE(tmp & 0x80);
@@ -1193,7 +1193,7 @@ void mos6502::Op_BCC(uint16_t src)
 	{
 		pc = src;
 		// TODO take an additional cycle if jumping across page boundries
-		opExtraCycles = 1;
+		opExtraCycles += 1;
 	}
 	return;
 }
@@ -1205,7 +1205,7 @@ void mos6502::Op_BCS(uint16_t src)
 	{
 		pc = src;
 		// TODO take an additional cycle if jumping across page boundries
-		opExtraCycles = 1;
+		opExtraCycles += 1;
 	}
 	return;
 }
@@ -1216,7 +1216,7 @@ void mos6502::Op_BEQ(uint16_t src)
 	{
 		pc = src;
 		// TODO take an additional cycle if jumping across page boundries
-		opExtraCycles = 1;
+		opExtraCycles += 1;
 	}
 	return;
 }
@@ -1237,7 +1237,7 @@ void mos6502::Op_BMI(uint16_t src)
 	{
 		pc = src;
 		// TODO take an additional cycle if jumping across page boundries
-		opExtraCycles = 1;
+		opExtraCycles += 1;
 	}
 	return;
 }
@@ -1248,7 +1248,7 @@ void mos6502::Op_BNE(uint16_t src)
 	{
 		pc = src;
 		// TODO take an additional cycle if jumping across page boundries
-		opExtraCycles = 1;
+		opExtraCycles += 1;
 	}
 	return;
 }
@@ -1259,7 +1259,7 @@ void mos6502::Op_BPL(uint16_t src)
 	{
 		pc = src;
 		// TODO take an additional cycle if jumping across page boundries
-		opExtraCycles = 1;
+		opExtraCycles += 1;
 	}
 	return;
 }
@@ -1653,7 +1653,7 @@ void mos6502::Op_SBC(uint16_t src)
 	if (IF_DECIMAL())
 	{
 		// An extra cycle is required if in decimal mode
-		opExtraCycles = 1;
+		opExtraCycles += 1;
 
 		if ( ((A & 0x0F) - (IF_CARRY() ? 0 : 1)) < (m & 0x0F)) tmp -= 6;
 		if (tmp > 0x99)

--- a/src/mos6502/mos6502.cpp
+++ b/src/mos6502/mos6502.cpp
@@ -1029,6 +1029,7 @@ void mos6502::Run(
 	CycleMethod cycleMethod
 ) {
 	uint8_t opcode;
+	uint8_t elapsedCycles;
 	Instr instr;
 
 	if(freeze) return;
@@ -1081,15 +1082,20 @@ void mos6502::Run(
 		if(illegalOpcode) {
 			illegalOpcodeSrc = opcode;
 		}
-		cycleCount += instr.cycles;
+
+		elapsedCycles = instr.cycles + opExtraCycles;
+		// The ops extra cycles have been accounted for, it must now be reset
+		opExtraCycles = 0;
+
+		cycleCount += elapsedCycles;
 		cyclesRemaining -=
-			(cycleMethod == CYCLE_COUNT )       ? instr.cycles
+			(cycleMethod == CYCLE_COUNT )       ? elapsedCycles
 			/* cycleMethod == INST_COUNT */   : 1;
 		if(irq_timer > 0) {
-			if(irq_timer < instr.cycles) {
+			if(irq_timer < elapsedCycles) {
 				irq_timer = 0;
 			} else {
-				irq_timer -= instr.cycles;
+				irq_timer -= elapsedCycles;
 			}
 			if(irq_timer == 0) {
 				if((irq_gate == NULL) || (*irq_gate)) {

--- a/src/mos6502/mos6502.cpp
+++ b/src/mos6502/mos6502.cpp
@@ -1188,6 +1188,8 @@ void mos6502::Op_BCC(uint16_t src)
 	if (!IF_CARRY())
 	{
 		pc = src;
+		// TODO take an additional cycle if jumping across page boundries
+		opExtraCycles = 1;
 	}
 	return;
 }
@@ -1198,6 +1200,8 @@ void mos6502::Op_BCS(uint16_t src)
 	if (IF_CARRY())
 	{
 		pc = src;
+		// TODO take an additional cycle if jumping across page boundries
+		opExtraCycles = 1;
 	}
 	return;
 }
@@ -1207,6 +1211,8 @@ void mos6502::Op_BEQ(uint16_t src)
 	if (IF_ZERO())
 	{
 		pc = src;
+		// TODO take an additional cycle if jumping across page boundries
+		opExtraCycles = 1;
 	}
 	return;
 }
@@ -1226,6 +1232,8 @@ void mos6502::Op_BMI(uint16_t src)
 	if (IF_NEGATIVE())
 	{
 		pc = src;
+		// TODO take an additional cycle if jumping across page boundries
+		opExtraCycles = 1;
 	}
 	return;
 }
@@ -1235,6 +1243,8 @@ void mos6502::Op_BNE(uint16_t src)
 	if (!IF_ZERO())
 	{
 		pc = src;
+		// TODO take an additional cycle if jumping across page boundries
+		opExtraCycles = 1;
 	}
 	return;
 }
@@ -1244,6 +1254,8 @@ void mos6502::Op_BPL(uint16_t src)
 	if (!IF_NEGATIVE())
 	{
 		pc = src;
+		// TODO take an additional cycle if jumping across page boundries
+		opExtraCycles = 1;
 	}
 	return;
 }
@@ -1742,6 +1754,7 @@ void mos6502::Op_TYA(uint16_t src)
 
 void mos6502::Op_BRA(uint16_t src)
 {
+	// TODO take an additional cycle if jumping across page boundries
 	pc = src;
 	return;
 }

--- a/src/mos6502/mos6502.cpp
+++ b/src/mos6502/mos6502.cpp
@@ -845,9 +845,6 @@ uint16_t mos6502::Addr_REL()
 	if (offset & 0x80) offset |= 0xFF00;
 	addr = pc + (int16_t)offset;
 
-	// An extra cycle is required if a page boundary is crossed
-	if (!addressesSamePage(pc, addr)) opExtraCycles++;
-
 	return addr;
 }
 
@@ -1220,8 +1217,11 @@ void mos6502::Op_BCC(uint16_t src)
 {
 	if (!IF_CARRY())
 	{
+		// An extra cycle is required if a page boundary is crossed
+		if (!addressesSamePage(pc, src)) opExtraCycles++;
+
 		pc = src;
-		opExtraCycles += 1;
+		opExtraCycles++;
 	}
 	return;
 }
@@ -1231,8 +1231,11 @@ void mos6502::Op_BCS(uint16_t src)
 {
 	if (IF_CARRY())
 	{
+		// An extra cycle is required if a page boundary is crossed
+		if (!addressesSamePage(pc, src)) opExtraCycles++;
+
 		pc = src;
-		opExtraCycles += 1;
+		opExtraCycles++;
 	}
 	return;
 }
@@ -1241,8 +1244,11 @@ void mos6502::Op_BEQ(uint16_t src)
 {
 	if (IF_ZERO())
 	{
+		// An extra cycle is required if a page boundary is crossed
+		if (!addressesSamePage(pc, src)) opExtraCycles++;
+
 		pc = src;
-		opExtraCycles += 1;
+		opExtraCycles++;
 	}
 	return;
 }
@@ -1261,8 +1267,11 @@ void mos6502::Op_BMI(uint16_t src)
 {
 	if (IF_NEGATIVE())
 	{
+		// An extra cycle is required if a page boundary is crossed
+		if (!addressesSamePage(pc, src)) opExtraCycles++;
+
 		pc = src;
-		opExtraCycles += 1;
+		opExtraCycles++;
 	}
 	return;
 }
@@ -1271,8 +1280,11 @@ void mos6502::Op_BNE(uint16_t src)
 {
 	if (!IF_ZERO())
 	{
+		// An extra cycle is required if a page boundary is crossed
+		if (!addressesSamePage(pc, src)) opExtraCycles++;
+
 		pc = src;
-		opExtraCycles += 1;
+		opExtraCycles++;
 	}
 	return;
 }
@@ -1281,8 +1293,11 @@ void mos6502::Op_BPL(uint16_t src)
 {
 	if (!IF_NEGATIVE())
 	{
+		// An extra cycle is required if a page boundary is crossed
+		if (!addressesSamePage(pc, src)) opExtraCycles++;
+
 		pc = src;
-		opExtraCycles += 1;
+		opExtraCycles++;
 	}
 	return;
 }
@@ -1313,7 +1328,11 @@ void mos6502::Op_BVC(uint16_t src)
 {
 	if (!IF_OVERFLOW())
 	{
+		// An extra cycle is required if a page boundary is crossed
+		if (!addressesSamePage(pc, src)) opExtraCycles++;
+
 		pc = src;
+		opExtraCycles++;
 	}
 	return;
 }
@@ -1322,7 +1341,11 @@ void mos6502::Op_BVS(uint16_t src)
 {
 	if (IF_OVERFLOW())
 	{
+		// An extra cycle is required if a page boundary is crossed
+		if (!addressesSamePage(pc, src)) opExtraCycles++;
+
 		pc = src;
+		opExtraCycles++;
 	}
 	return;
 }
@@ -1784,6 +1807,9 @@ void mos6502::Op_TYA(uint16_t src)
 
 void mos6502::Op_BRA(uint16_t src)
 {
+	// An extra cycle is required if a page boundary is crossed
+	if (!addressesSamePage(pc, src)) opExtraCycles++;
+
 	pc = src;
 	return;
 }

--- a/src/mos6502/mos6502.cpp
+++ b/src/mos6502/mos6502.cpp
@@ -794,6 +794,14 @@ mos6502::mos6502(BusRead r, BusWrite w, CPUEvent stp, BusRead sync)
 	return;
 }
 
+// Small helper function to test if addresses belong to the same page
+// This is useful for conditional timing as some addressing modes take additional cycles if calculated
+// addresses cross page boundaries
+inline bool mos6502::addressesSamePage(uint16_t a, uint16_t b)
+{
+	return (a & 0xFF00 == b & 0xFF00);
+}
+
 uint16_t mos6502::Addr_ACC()
 {
 	return 0; // not used
@@ -838,7 +846,7 @@ uint16_t mos6502::Addr_REL()
 	addr = pc + (int16_t)offset;
 
 	// An extra cycle is required if a page boundary is crossed
-	if (addr & 0xFF00 != pc & 0xFF00) opExtraCycles += 1;
+	if (!addressesSamePage(pc, addr)) opExtraCycles++;
 
 	return addr;
 }
@@ -896,7 +904,7 @@ uint16_t mos6502::Addr_ABX()
 	addr = addrBase + X;
 
 	// An extra cycle is required if a page boundary is crossed
-	if (addrBase & 0xFF00 != addr & 0xFF00) opExtraCycles += 1;
+	if (!addressesSamePage(addr, addrBase)) opExtraCycles++;
 
 	return addr;
 }
@@ -915,7 +923,7 @@ uint16_t mos6502::Addr_ABY()
 	addr = addrBase + Y;
 
 	// An extra cycle is required if a page boundary is crossed
-	if (addrBase & 0xFF00 != addr & 0xFF00) opExtraCycles += 1;
+	if (!addressesSamePage(addr, addrBase)) opExtraCycles++;
 
 	return addr;
 }
@@ -947,7 +955,7 @@ uint16_t mos6502::Addr_INY()
 	addr = addrBase + Y;
 
 	// An extra cycle is required if a page boundary is crossed
-	if (addrBase & 0xFF00 != addr & 0xFF00) opExtraCycles += 1;
+	if (!addressesSamePage(addr, addrBase)) opExtraCycles++;
 
 	return addr;
 }

--- a/src/mos6502/mos6502.cpp
+++ b/src/mos6502/mos6502.cpp
@@ -836,6 +836,10 @@ uint16_t mos6502::Addr_REL()
 	offset = (uint16_t)Read(pc++);
 	if (offset & 0x80) offset |= 0xFF00;
 	addr = pc + (int16_t)offset;
+
+	// An extra cycle is required if a page boundary is crossed
+	if (addr & 0xFF00 != pc & 0xFF00) opExtraCycles += 1;
+
 	return addr;
 }
 
@@ -1192,7 +1196,6 @@ void mos6502::Op_BCC(uint16_t src)
 	if (!IF_CARRY())
 	{
 		pc = src;
-		// TODO take an additional cycle if jumping across page boundries
 		opExtraCycles += 1;
 	}
 	return;
@@ -1204,7 +1207,6 @@ void mos6502::Op_BCS(uint16_t src)
 	if (IF_CARRY())
 	{
 		pc = src;
-		// TODO take an additional cycle if jumping across page boundries
 		opExtraCycles += 1;
 	}
 	return;
@@ -1215,7 +1217,6 @@ void mos6502::Op_BEQ(uint16_t src)
 	if (IF_ZERO())
 	{
 		pc = src;
-		// TODO take an additional cycle if jumping across page boundries
 		opExtraCycles += 1;
 	}
 	return;
@@ -1236,7 +1237,6 @@ void mos6502::Op_BMI(uint16_t src)
 	if (IF_NEGATIVE())
 	{
 		pc = src;
-		// TODO take an additional cycle if jumping across page boundries
 		opExtraCycles += 1;
 	}
 	return;
@@ -1247,7 +1247,6 @@ void mos6502::Op_BNE(uint16_t src)
 	if (!IF_ZERO())
 	{
 		pc = src;
-		// TODO take an additional cycle if jumping across page boundries
 		opExtraCycles += 1;
 	}
 	return;
@@ -1258,7 +1257,6 @@ void mos6502::Op_BPL(uint16_t src)
 	if (!IF_NEGATIVE())
 	{
 		pc = src;
-		// TODO take an additional cycle if jumping across page boundries
 		opExtraCycles += 1;
 	}
 	return;
@@ -1761,7 +1759,6 @@ void mos6502::Op_TYA(uint16_t src)
 
 void mos6502::Op_BRA(uint16_t src)
 {
-	// TODO take an additional cycle if jumping across page boundries
 	pc = src;
 	return;
 }

--- a/src/mos6502/mos6502.h
+++ b/src/mos6502/mos6502.h
@@ -183,6 +183,10 @@ private:
 	//If not null, this is checked before actually sending IRQ
 	bool *irq_gate;
 
+	// Some ops will take extra cycles based on factors like page boundries and processor status
+	// Record the extra cycles into this value during execution
+	uint8_t opExtraCycles = 0;
+
 public:
 	bool freeze = false;
 	bool illegalOpcode = false;

--- a/src/mos6502/mos6502.h
+++ b/src/mos6502/mos6502.h
@@ -58,6 +58,9 @@ private:
 
 	void Exec(Instr i);
 
+	// Helper function for determining if two addresses are in the same page
+	inline bool addressesSamePage(uint16_t a, uint16_t b);
+
 	// addressing modes
 	uint16_t Addr_ACC(); // ACCUMULATOR
 	uint16_t Addr_IMM(); // IMMEDIATE


### PR DESCRIPTION
This pr is a simplified version of #43 based off a suggestion from @clydeshaffer 

This pr adds extra cycles to the following cases:
- `ADC` `SBC` in decimal mode
- Jumps when taken
- A further additional cycle when the taken jump is across a page boundary
- Calculating instructions in addressing modes absolute indexed by x or y and indirect indexed by y if the calculated address crosses a page boundary

This should improve cycle accuracy of the emulator