### PR TITLE
Adds some missing ops

### DIFF
--- a/src/devtools/disassembler.cpp
+++ b/src/devtools/disassembler.cpp
@@ -30,50 +30,51 @@ vector<string> Disassembler::opcodeNames = {
     };
 
 Disassembler::ArgIsLabel Disassembler::opcodeTakesLabels[256] = {
-    N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,
-    DL,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,
-    AL,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,
-    DL,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,
-    N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,AL,N_,N_,N_,
-    DL,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,
-    N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,AL,N_,N_,N_,
-    DL,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,AL,N_,N_,N_,
-    DL,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,
-    DL,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,
-    N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,
-    DL,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,
-    N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,
-    DL,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,
-    N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,
-    DL,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,
+    N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,DL,
+    DL,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,DL,
+    AL,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,DL,
+    DL,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,DL,
+    N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,AL,N_,N_,DL,
+    DL,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,DL,
+    N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,AL,N_,N_,DL,
+    DL,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,AL,N_,N_,DL,
+    DL,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,DL,
+    DL,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,DL,
+    N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,DL,
+    DL,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,DL,
+    N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,DL,
+    DL,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,DL,
+    N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,DL,
+    DL,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,N_,DL,
 };
 
 Disassembler::AddressMode Disassembler::opcodeModes[256] = {
     //BRK is listed as "stack" address mode but is a two byte instruction
-    NO,IX,XX,XX,ZP,ZP,ZP,ZP,ST,NO,AC,XX,AB,AB,AB,PR,
-    PR,IY,ZI,XX,ZP,ZX,ZX,ZP,IM,AY,AC,XX,AB,AX,AX,PR,
-    AB,IX,XX,XX,ZP,ZP,ZP,ZP,ST,NO,AC,XX,AB,AB,AB,PR,
-    PR,IY,ZI,XX,ZX,ZX,ZX,ZP,IM,AY,AC,XX,AX,AX,AX,PR,
-    ST,IX,XX,XX,XX,ZP,ZP,ZP,ST,NO,AC,XX,AB,AB,AB,PR,
-    PR,IY,ZI,XX,XX,ZX,ZX,ZP,IM,AY,AC,XX,XX,AX,AX,PR,
-    ST,IX,XX,XX,ZP,ZP,ZP,ZP,ST,NO,AC,XX,AI,AB,AB,PR,
-    PR,IY,ZI,XX,ZX,ZX,ZX,ZP,IM,AY,ST,XX,JX,AX,AX,PR,
-    PR,IX,XX,XX,ZP,ZP,ZP,ZP,IM,NO,IM,XX,AB,AB,AB,PR,
-    PR,IY,ZI,XX,ZX,ZX,ZY,ZP,IM,AY,IM,XX,AB,AX,AX,PR,
-    NO,IX,NO,XX,ZP,ZP,ZP,ZP,IM,NO,IM,XX,AB,AB,AB,PR,
-    PR,IY,ZI,XX,ZX,ZX,ZY,ZP,IM,AY,IM,XX,AX,AX,AY,PR,
-    NO,IX,XX,XX,ZP,ZP,ZP,ZP,IM,NO,IM,IM,AB,AB,AB,PR,
-    PR,IY,ZI,XX,XX,ZX,ZX,ZP,IM,AY,ST,IM,XX,AX,AX,PR,
-    NO,IX,XX,XX,ZP,ZP,ZP,ZP,IM,NO,IM,XX,AB,AB,AB,PR,
-    PR,IY,ZI,XX,XX,ZX,ZX,ZP,IM,AY,ST,XX,XX,AX,AX,PR
+    NO,IX,XX,XX,ZP,ZP,ZP,ZP,ST,NO,AC,XX,AB,AB,AB,BB,
+    PR,IY,ZI,XX,ZP,ZX,ZX,ZP,IM,AY,AC,XX,AB,AX,AX,BB,
+    AB,IX,XX,XX,ZP,ZP,ZP,ZP,ST,NO,AC,XX,AB,AB,AB,BB,
+    PR,IY,ZI,XX,ZX,ZX,ZX,ZP,IM,AY,AC,XX,AX,AX,AX,BB,
+    ST,IX,XX,XX,XX,ZP,ZP,ZP,ST,NO,AC,XX,AB,AB,AB,BB,
+    PR,IY,ZI,XX,XX,ZX,ZX,ZP,IM,AY,AC,XX,XX,AX,AX,BB,
+    ST,IX,XX,XX,ZP,ZP,ZP,ZP,ST,NO,AC,XX,AI,AB,AB,BB,
+    PR,IY,ZI,XX,ZX,ZX,ZX,ZP,IM,AY,ST,XX,JX,AX,AX,BB,
+    PR,IX,XX,XX,ZP,ZP,ZP,ZP,IM,NO,IM,XX,AB,AB,AB,BB,
+    PR,IY,ZI,XX,ZX,ZX,ZY,ZP,IM,AY,IM,XX,AB,AX,AX,BB,
+    NO,IX,NO,XX,ZP,ZP,ZP,ZP,IM,NO,IM,XX,AB,AB,AB,BB,
+    PR,IY,ZI,XX,ZX,ZX,ZY,ZP,IM,AY,IM,XX,AX,AX,AY,BB,
+    NO,IX,XX,XX,ZP,ZP,ZP,ZP,IM,NO,IM,IM,AB,AB,AB,BB,
+    PR,IY,ZI,XX,XX,ZX,ZX,ZP,IM,AY,ST,IM,XX,AX,AX,BB,
+    NO,IX,XX,XX,ZP,ZP,ZP,ZP,IM,NO,IM,XX,AB,AB,AB,BB,
+    PR,IY,ZI,XX,XX,ZX,ZX,ZP,IM,AY,ST,XX,XX,AX,AX,BB,
 };
 
-static size_t opBytes[17] = {
+static size_t opBytes[18] = {
     1,
     3, 3, 3, 3,
     3, 1, 2, 1,
     2, 1, 2, 2,
     2, 2, 2, 2,
+    3,
 };
 
 
@@ -198,6 +199,38 @@ void Disassembler::FormatArgBytes(std::stringstream& ss, MemoryMap* mem_map, uin
                 //Zero Page Indirect Indexed Y
                 argstream << "($" << FMT_ARG << "), y";
                 break;
+	    case BB: {
+		// BB Weird instruction style used by BBRx and BBSx instructions
+		// Unlike all other instructions this takes two arguments
+		// First, a location in the zero page to test the given bit of
+		uint16_t zpArg = (argBytes & 0x00FF);
+		// Second, an relative jump offset
+		uint16_t relArg = (argBytes & 0xFF00) >> 8;
+		// In this regard it is sort of like a zero page and relative instruction combined
+		// Because this takes multiple distinct args, we won't be able to make use of the FMT_ARG marco here :(
+
+		// Print the first argument and separator here
+		// TODO might want to check for named zero page items in the first argument
+		argstream << "$" << std::setw(2) << std::setfill('0') << std::right << std::hex << zpArg << ", ";
+
+		// Print the second arg
+		// First check if it is a named label if so print the label
+		// Otherwise print it as a normal offset
+                if (mem_map && opcodeTakesLabels[opcode] == DL) {
+                    Symbol sym;
+                    // Check to see if the branch target is a named label
+		    // Note that we only want the least significant byte of the argument
+                    if(mem_map->FindAddress(address + (char) relArg, &sym)) {
+                        string name = sym.name;
+                        argstream << name;
+                        break;
+                    }
+                }
+
+		// Not a named label, print as a normal offset
+		argstream << "$" << std::setw(2) << std::setfill('0') << std::right << std::hex << relArg;
+                break;
+	    }
             case XX:
                 //Treat invalid opcode as no bytes
                 break;

--- a/src/devtools/disassembler.h
+++ b/src/devtools/disassembler.h
@@ -25,7 +25,8 @@ private:
         AB, JX, AX, AY,
         AI, AC, NO, IM,
         PR, ST, ZP, IX,
-        ZX, ZY, ZI, IY
+        ZX, ZY, ZI, IY,
+        BB
     };
     enum ArgIsLabel {
         // Not Label

--- a/src/mos6502/mos6502.cpp
+++ b/src/mos6502/mos6502.cpp
@@ -792,6 +792,21 @@ mos6502::mos6502(BusRead r, BusWrite w, CPUEvent stp, BusRead sync)
 	instr.cycles = 5;
 	InstrTable[0x04] = instr;
 
+	// New addressing modes for BIT
+	instr.addr = &mos6502::Addr_IMM;
+	instr.code = &mos6502::Op_BIT;
+	instr.cycles = 2;
+	InstrTable[0x89] = instr;
+
+	instr.addr = &mos6502::addr_ZEX;
+	instr.code = &mos6502::op_BIT;
+	instr.cycles = 4;
+	instrtable[0x34] = instr;
+
+	instr.addr = &mos6502::Addr_ABX;
+	instr.code = &mos6502::op_BIT;
+	instr.cycles = 4;
+	instrtable[0x3C] = instr;
 
 	Reset();
 

--- a/src/mos6502/mos6502.cpp
+++ b/src/mos6502/mos6502.cpp
@@ -895,7 +895,7 @@ mos6502::mos6502(BusRead r, BusWrite w, CPUEvent stp, BusRead sync)
 	instr.addr = &mos6502::Addr_AIX;
 	instr.code = &mos6502::Op_JMP;
 	instr.cycles = 6;
-	instrTable[0x7C] = instr;
+	InstrTable[0x7C] = instr;
 
 	Reset();
 
@@ -995,7 +995,8 @@ uint16_t mos6502::Addr_AIX()
 	addrL = Read(pc++);
 	addrH = Read(pc++);
 
-	abs = (addrH << 8) | addrL;
+	// Offset the calculated absolute address by X
+	abs = ((addrH << 8) | addrL) + X;
 
 	effL = Read(abs);
 
@@ -1006,8 +1007,6 @@ uint16_t mos6502::Addr_AIX()
 #endif
 
 	addr = effL + 0x100 * effH;
-
-	addr = addr + X;
 
 	return addr;
 }

--- a/src/mos6502/mos6502.cpp
+++ b/src/mos6502/mos6502.cpp
@@ -798,15 +798,98 @@ mos6502::mos6502(BusRead r, BusWrite w, CPUEvent stp, BusRead sync)
 	instr.cycles = 2;
 	InstrTable[0x89] = instr;
 
-	instr.addr = &mos6502::addr_ZEX;
-	instr.code = &mos6502::op_BIT;
+	instr.addr = &mos6502::Addr_ZEX;
+	instr.code = &mos6502::Op_BIT;
 	instr.cycles = 4;
-	instrtable[0x34] = instr;
+	InstrTable[0x34] = instr;
 
 	instr.addr = &mos6502::Addr_ABX;
-	instr.code = &mos6502::op_BIT;
+	instr.code = &mos6502::Op_BIT;
 	instr.cycles = 4;
-	instrtable[0x3C] = instr;
+	InstrTable[0x3C] = instr;
+
+	// BBRx and BBSx
+	// NOTE these instructions are weird and use their own addressing mode
+	// Instead I'll opt for implied and handle within the codes
+	instr.addr = &mos6502::Addr_IMP;
+	instr.code = &mos6502::Op_BBR0;
+	instr.cycles = 5;
+	InstrTable[0x0F] = instr;
+
+	instr.addr = &mos6502::Addr_IMP;
+	instr.code = &mos6502::Op_BBR1;
+	instr.cycles = 5;
+	InstrTable[0x1F] = instr;
+
+	instr.addr = &mos6502::Addr_IMP;
+	instr.code = &mos6502::Op_BBR2;
+	instr.cycles = 5;
+	InstrTable[0x2F] = instr;
+
+	instr.addr = &mos6502::Addr_IMP;
+	instr.code = &mos6502::Op_BBR3;
+	instr.cycles = 5;
+	InstrTable[0x3F] = instr;
+
+	instr.addr = &mos6502::Addr_IMP;
+	instr.code = &mos6502::Op_BBR4;
+	instr.cycles = 5;
+	InstrTable[0x4F] = instr;
+
+	instr.addr = &mos6502::Addr_IMP;
+	instr.code = &mos6502::Op_BBR5;
+	instr.cycles = 5;
+	InstrTable[0x5F] = instr;
+
+	instr.addr = &mos6502::Addr_IMP;
+	instr.code = &mos6502::Op_BBR6;
+	instr.cycles = 5;
+	InstrTable[0x6F] = instr;
+
+	instr.addr = &mos6502::Addr_IMP;
+	instr.code = &mos6502::Op_BBR7;
+	instr.cycles = 5;
+	InstrTable[0x7F] = instr;
+
+	instr.addr = &mos6502::Addr_IMP;
+	instr.code = &mos6502::Op_BBS0;
+	instr.cycles = 5;
+	InstrTable[0x8F] = instr;
+
+	instr.addr = &mos6502::Addr_IMP;
+	instr.code = &mos6502::Op_BBS1;
+	instr.cycles = 5;
+	InstrTable[0x9F] = instr;
+
+	instr.addr = &mos6502::Addr_IMP;
+	instr.code = &mos6502::Op_BBS2;
+	instr.cycles = 5;
+	InstrTable[0xAF] = instr;
+
+	instr.addr = &mos6502::Addr_IMP;
+	instr.code = &mos6502::Op_BBS3;
+	instr.cycles = 5;
+	InstrTable[0xBF] = instr;
+
+	instr.addr = &mos6502::Addr_IMP;
+	instr.code = &mos6502::Op_BBS4;
+	instr.cycles = 5;
+	InstrTable[0xCF] = instr;
+
+	instr.addr = &mos6502::Addr_IMP;
+	instr.code = &mos6502::Op_BBS5;
+	instr.cycles = 5;
+	InstrTable[0xDF] = instr;
+
+	instr.addr = &mos6502::Addr_IMP;
+	instr.code = &mos6502::Op_BBS6;
+	instr.cycles = 5;
+	InstrTable[0xEF] = instr;
+
+	instr.addr = &mos6502::Addr_IMP;
+	instr.code = &mos6502::Op_BBS7;
+	instr.cycles = 5;
+	InstrTable[0xFF] = instr;
 
 	Reset();
 
@@ -1847,4 +1930,168 @@ void mos6502::Op_TSB(uint16_t src)
 	SET_ZERO(m & A);
 	m = m | A;
 	Write(src, m);
+}
+
+void mos6502::Op_BBRx(uint8_t mask, uint8_t val, uint16_t offset)
+{
+	uint16_t addr;
+
+	if ((val & mask) == 0) {
+		// Taking the branch incurs an additional cycle
+		opExtraCycles++;
+
+		if (offset & 0x80) offset |= 0xFF00;
+		addr = pc + (int16_t)offset;
+
+		// Crossing page boundary incurs another additional cycle
+		if (addressesSamePage(addr, pc)) opExtraCycles++;
+
+		pc = addr;
+	}
+}
+
+void mos6502::Op_BBR0(uint16_t src)
+{
+	auto val = Read(Read(pc++));
+	uint16_t offset = (uint16_t) Read(pc++);
+
+	Op_BBRx(0x01, val, offset);
+}
+
+void mos6502::Op_BBR1(uint16_t src)
+{
+	auto val = Read(Read(pc++));
+	uint16_t offset = (uint16_t) Read(pc++);
+
+	Op_BBRx(0x02, val, offset);
+}
+
+void mos6502::Op_BBR2(uint16_t src)
+{
+	auto val = Read(Read(pc++));
+	uint16_t offset = (uint16_t) Read(pc++);
+
+	Op_BBRx(0x04, val, offset);
+}
+
+void mos6502::Op_BBR3(uint16_t src)
+{
+	auto val = Read(Read(pc++));
+	uint16_t offset = (uint16_t) Read(pc++);
+
+	Op_BBRx(0x08, val, offset);
+}
+
+void mos6502::Op_BBR4(uint16_t src)
+{
+	auto val = Read(Read(pc++));
+	uint16_t offset = (uint16_t) Read(pc++);
+
+	Op_BBRx(0x10, val, offset);
+}
+
+void mos6502::Op_BBR5(uint16_t src)
+{
+	auto val = Read(Read(pc++));
+	uint16_t offset = (uint16_t) Read(pc++);
+
+	Op_BBRx(0x20, val, offset);
+}
+
+void mos6502::Op_BBR6(uint16_t src)
+{
+	auto val = Read(Read(pc++));
+	uint16_t offset = (uint16_t) Read(pc++);
+
+	Op_BBRx(0x40, val, offset);
+}
+
+void mos6502::Op_BBR7(uint16_t src)
+{
+	auto val = Read(Read(pc++));
+	uint16_t offset = (uint16_t) Read(pc++);
+
+	Op_BBRx(0x80, val, offset);
+}
+
+void mos6502::Op_BBSx(uint8_t mask, uint8_t val, uint16_t offset)
+{
+	uint16_t addr;
+
+	if ((val & mask) != 0) {
+		// Taking the branch, additional cycle
+		opExtraCycles++;
+
+		if (offset & 0x80) offset |= 0xFF00;
+		addr = pc + (int16_t)offset;
+
+		// Crossing page boundary incurs an additional cycle
+		if (addressesSamePage(addr, pc)) opExtraCycles++;
+
+		pc = addr;
+	}
+}
+
+void mos6502::Op_BBS0(uint16_t src)
+{
+	auto val = Read(Read(pc++));
+	uint16_t offset = (uint16_t) Read(pc++);
+
+	Op_BBSx(0x01, val, offset);
+}
+
+void mos6502::Op_BBS1(uint16_t src)
+{
+	auto val = Read(Read(pc++));
+	uint16_t offset = (uint16_t) Read(pc++);
+
+	Op_BBSx(0x02, val, offset);
+}
+
+void mos6502::Op_BBS2(uint16_t src)
+{
+	auto val = Read(Read(pc++));
+	uint16_t offset = (uint16_t) Read(pc++);
+
+	Op_BBSx(0x04, val, offset);
+}
+
+void mos6502::Op_BBS3(uint16_t src)
+{
+	auto val = Read(Read(pc++));
+	uint16_t offset = (uint16_t) Read(pc++);
+
+	Op_BBSx(0x08, val, offset);
+}
+
+void mos6502::Op_BBS4(uint16_t src)
+{
+	auto val = Read(Read(pc++));
+	uint16_t offset = (uint16_t) Read(pc++);
+
+	Op_BBSx(0x10, val, offset);
+}
+
+void mos6502::Op_BBS5(uint16_t src)
+{
+	auto val = Read(Read(pc++));
+	uint16_t offset = (uint16_t) Read(pc++);
+
+	Op_BBSx(0x20, val, offset);
+}
+
+void mos6502::Op_BBS6(uint16_t src)
+{
+	auto val = Read(Read(pc++));
+	uint16_t offset = (uint16_t) Read(pc++);
+
+	Op_BBSx(0x40, val, offset);
+}
+
+void mos6502::Op_BBS7(uint16_t src)
+{
+	auto val = Read(Read(pc++));
+	uint16_t offset = (uint16_t) Read(pc++);
+
+	Op_BBSx(0x80, val, offset);
 }

--- a/src/mos6502/mos6502.cpp
+++ b/src/mos6502/mos6502.cpp
@@ -112,7 +112,8 @@ mos6502::mos6502(BusRead r, BusWrite w, CPUEvent stp, BusRead sync)
 	InstrTable[0x16] = instr;
 	instr.addr = &mos6502::Addr_ABX;
 	instr.code = &mos6502::Op_ASL;
-	instr.cycles = 7;
+	// 65c02 note: this instruction now takes 6+ cycles instead of 7 on the 6502
+	instr.cycles = 6;
 	InstrTable[0x1E] = instr;
 
 	instr.addr = &mos6502::Addr_REL;
@@ -475,7 +476,8 @@ mos6502::mos6502(BusRead r, BusWrite w, CPUEvent stp, BusRead sync)
 	InstrTable[0x56] = instr;
 	instr.addr = &mos6502::Addr_ABX;
 	instr.code = &mos6502::Op_LSR;
-	instr.cycles = 7;
+	// 65c02 note: this instruction now takes 6+ cycles instead of 7 on the 6502
+	instr.cycles = 6;
 	InstrTable[0x5E] = instr;
 
 	instr.addr = &mos6502::Addr_IMP;
@@ -578,7 +580,8 @@ mos6502::mos6502(BusRead r, BusWrite w, CPUEvent stp, BusRead sync)
 	InstrTable[0x36] = instr;
 	instr.addr = &mos6502::Addr_ABX;
 	instr.code = &mos6502::Op_ROL;
-	instr.cycles = 7;
+	// 65c02 note: this instruction now takes 6+ cycles instead of 7 on the 6502
+	instr.cycles = 6;
 	InstrTable[0x3E] = instr;
 
 	instr.addr = &mos6502::Addr_ABS;
@@ -599,7 +602,8 @@ mos6502::mos6502(BusRead r, BusWrite w, CPUEvent stp, BusRead sync)
 	InstrTable[0x76] = instr;
 	instr.addr = &mos6502::Addr_ABX;
 	instr.code = &mos6502::Op_ROR;
-	instr.cycles = 7;
+	// 65c02 note: this instruction now takes 6+ cycles instead of 7 on the 6502
+	instr.cycles = 6;
 	InstrTable[0x7E] = instr;
 
 	instr.addr = &mos6502::Addr_IMP;

--- a/src/mos6502/mos6502.h
+++ b/src/mos6502/mos6502.h
@@ -80,6 +80,7 @@ private:
 	uint16_t Addr_INY(); // INDEXED-Y INDIRECT
 	uint16_t Addr_ABI(); // ABSOLUTE INDIRECT
 	uint16_t Addr_ZPI(); // ZERO PAGE INDIRECT
+	uint16_t Addr_AIX(); // ABSOLUTE INDIRECT INDEXED-X
 
 	// opcodes (grouped as per datasheet)
 	void Op_ADC(uint16_t src);

--- a/src/mos6502/mos6502.h
+++ b/src/mos6502/mos6502.h
@@ -61,6 +61,10 @@ private:
 	// Helper function for determining if two addresses are in the same page
 	inline bool addressesSamePage(uint16_t a, uint16_t b);
 
+	// Helper functions for the BBRx and BBSx instructions
+	void Op_BBRx(uint8_t mask, uint8_t val, uint16_t offset);
+	void Op_BBSx(uint8_t mask, uint8_t val, uint16_t offset);
+
 	// addressing modes
 	uint16_t Addr_ACC(); // ACCUMULATOR
 	uint16_t Addr_IMM(); // IMMEDIATE
@@ -155,6 +159,24 @@ private:
 	void Op_BRA(uint16_t src);
 	void Op_TRB(uint16_t src);
 	void Op_TSB(uint16_t src);
+
+	void Op_BBR0(uint16_t src);
+	void Op_BBR1(uint16_t src);
+	void Op_BBR2(uint16_t src);
+	void Op_BBR3(uint16_t src);
+	void Op_BBR4(uint16_t src);
+	void Op_BBR5(uint16_t src);
+	void Op_BBR6(uint16_t src);
+	void Op_BBR7(uint16_t src);
+
+	void Op_BBS0(uint16_t src);
+	void Op_BBS1(uint16_t src);
+	void Op_BBS2(uint16_t src);
+	void Op_BBS3(uint16_t src);
+	void Op_BBS4(uint16_t src);
+	void Op_BBS5(uint16_t src);
+	void Op_BBS6(uint16_t src);
+	void Op_BBS7(uint16_t src);
 
 	void Op_ILLEGAL(uint16_t src);
 


### PR DESCRIPTION
- Corrects timing for ASL LSR ROL ROR (65c02 change)
- Adds 65c02 addressing modes for BIT
- Support for BBRx and BBSx
- Support for (abs, x) addressing mode of JMP

A note on implementation of BBRx and BBSx: these two instructions don't use an addressing mode like any other instructions. They take two arguments, the zero page address to be tested and the jump offset. Instead I just set the instructions to use implied addressing (does nothing) and take care of the arguments within the instructions themselves.

View of (some of the) new instructions in the disassembler
![Screenshot from 2024-11-21 19-33-17](https://github.com/user-attachments/assets/c3c74028-5d7b-4300-bee4-6e1ae36ffc16)