### PR TITLE
Fix missing serialization for system button input binding

### DIFF
--- a/src/joystick_config.cpp
+++ b/src/joystick_config.cpp
@@ -53,6 +53,10 @@ void save_joystick_config(std::vector<InputBinding> &bindings) {
 			case BindingTypes::JOYSTICK_HAT:
 			bindTomlEntry.emplace("joyHat", bindEntry.host_input.joy_button);
 			break;
+			case BindingTypes::JOYSTICK_BUTTON_SYSTEM:
+			bindTomlEntry.emplace("joyButton", bindEntry.host_input.joy_button);
+			break;
+
 		}
 		bindArray.emplace_back(bindTomlEntry);
 	}
@@ -92,6 +96,10 @@ void load_joystick_config(std::vector<InputBinding> &bindings) {
 						case BindingTypes::JOYSTICK_HAT:
 						bind.host_input.joy_button = (int64_t) (*tbl->get_as<int64_t>("joyHat"));
 						break;
+						case BindingTypes::JOYSTICK_BUTTON_SYSTEM:
+						bind.host_input.joy_button = (int64_t) (*tbl->get_as<int64_t>("joyButton"));
+						break;
+
 					}
 					bindings.emplace_back(bind);
 			}

--- a/src/joystick_config.cpp
+++ b/src/joystick_config.cpp
@@ -56,7 +56,6 @@ void save_joystick_config(std::vector<InputBinding> &bindings) {
 			case BindingTypes::JOYSTICK_BUTTON_SYSTEM:
 			bindTomlEntry.emplace("joyButton", bindEntry.host_input.joy_button);
 			break;
-
 		}
 		bindArray.emplace_back(bindTomlEntry);
 	}
@@ -99,7 +98,6 @@ void load_joystick_config(std::vector<InputBinding> &bindings) {
 						case BindingTypes::JOYSTICK_BUTTON_SYSTEM:
 						bind.host_input.joy_button = (int64_t) (*tbl->get_as<int64_t>("joyButton"));
 						break;
-
 					}
 					bindings.emplace_back(bind);
 			}


### PR DESCRIPTION
### Description
This PR fixes an issue where the system/menu button binding mapping was not persisting across application restarts due to a serialization omission.

**Symptom:** On a `WRAPPERMODE` build, the emulator would stop responding to the physical Select button after the initial configuration file was generated, instead incorrectly triggering the menu layout via `D-pad Right`. 

### Cause
The `save_joystick_config` and `load_joystick_config` functions lacked a `switch` case for `BindingTypes::JOYSTICK_BUTTON_SYSTEM`. While the default hardcoded array correctly assigns `SDL_CONTROLLER_BUTTON_BACK`, any subsequent load from the generated TOML file skipped assigning the target value to `bind.host_input.joy_button`. This left the field uninitialized, using random stack data that evaluated to `SDL_CONTROLLER_BUTTON_DPAD_RIGHT` on certain runtimes.

### Changes
- Added `BindingTypes::JOYSTICK_BUTTON_SYSTEM` case to `save_joystick_config` to write the `joyButton` field to TOML.
- Added `BindingTypes::JOYSTICK_BUTTON_SYSTEM` case to `load_joystick_config` to read the `joyButton` field back into memory.