### PR TITLE
feature: Adds joystick paddle support

### DIFF
--- a/src/gte.cpp
+++ b/src/gte.cpp
@@ -36,6 +36,7 @@
 #include "ui/ui_utils.h"
 #include "devtools/profiler.h"
 #include "devtools/disassembler.h"
+#include "paddle.h"
 
 #ifndef WASM_BUILD
 #include "devtools/profiler_window.h"
@@ -103,7 +104,7 @@ int resetQueued = 0;
 #define MUTE_SOURCE_MANUAL 1
 #define MUTE_SOURCE_MENU 2
 int muteMask = 0;
-bool paddle_emulation_enabled = false;
+bool mouse_paddle_enabled = false;
 bool paddle_touch_mode = false;
 
 void SaveNVRAM() {
@@ -777,8 +778,8 @@ extern "C" {
 	extern "C" {
 		EMSCRIPTEN_KEEPALIVE
 		void SetPaddleMode(bool enabled) {
-			paddle_emulation_enabled = enabled;
-			if (paddle_emulation_enabled){
+			mouse_paddle_enabled = enabled;
+			if (mouse_paddle_enabled){
 				if (paddle_touch_mode) {
 					SDL_SetRelativeMouseMode(SDL_FALSE);
 				}
@@ -1039,8 +1040,14 @@ void refreshScreen() {
 				ImGui::MenuItem("Toggle Instant Blits", NULL, &(blitter->instant_mode));
 				ImGui::SliderInt("Volume", &AudioCoprocessor::singleton_acp_state->volume, 0, 256);
 				ImGui::Checkbox("Mute", &AudioCoprocessor::singleton_acp_state->isMuted);
-				if (ImGui::Checkbox("Enable Paddle Emulation", &paddle_emulation_enabled)) {
-					joysticks->SetHeldButtons(0);//clear bits on change just in case
+				if (ImGui::BeginMenu("Paddle Support")) {
+					if (ImGui::Checkbox("Enable Mouse Paddle", &mouse_paddle_enabled)) {
+						joysticks->SetHeldButtons(0);//clear bits on change just in case
+					}
+					if (ImGui::Checkbox("Enable Joystick Paddle", &joystick_paddle_enabled)) {
+						joysticks->SetHeldButtons(0);//clear bits on change just in case
+					}
+					ImGui::EndMenu();
 				}
 				if(ImGui::BeginMenu("Pallete")) {
 					ImGui::RadioButton("Unscaled Capture", &palette_select, PALETTE_SELECT_CAPTURE);
@@ -1146,9 +1153,15 @@ void refreshScreen() {
 			else muteMask &= ~MUTE_SOURCE_MANUAL;
 			AudioCoprocessor::singleton_acp_state->isMuted = (muteMask != 0);
 			ImGui::Separator();
-			if (ImGui::Checkbox("Enable Paddle Emulation", &paddle_emulation_enabled)) {
-				joysticks->SetHeldButtons(0);//clear bits on change just in case
-			}
+			if (ImGui::BeginMenu("Paddle Support")) {
+					if (ImGui::Checkbox("Enable Mouse Paddle", &mouse_paddle_enabled)) {
+						joysticks->SetHeldButtons(0);//clear bits on change just in case
+					}
+					if (ImGui::Checkbox("Enable Joystick Paddle", &joystick_paddle_enabled)) {
+						joysticks->SetHeldButtons(0);//clear bits on change just in case
+					}
+					ImGui::EndMenu();
+				}
 			ImGui::EndMenu();
 		}
 
@@ -1191,7 +1204,8 @@ EM_BOOL mainloop(double time, void* userdata) {
         }
         frame_time_accumulator -= target_frame_period_ms;
 #else 
-if (paddle_emulation_enabled) {
+
+if (mouse_paddle_enabled) {
 	if (paddle_touch_mode){ //touch / absolute
 		int mx, my, winW, winH;
 		SDL_GetMouseState(&mx, &my);
@@ -1208,6 +1222,16 @@ if (paddle_emulation_enabled) {
 		}
 	}
 }//mouse paddle emulation
+else if (joystick_paddle_enabled) {
+		// We treat the full joystick range as our "Window Width"
+		// Logical range of SDL Axis is 65535 units wide
+		const int virtualWidth = 65535;
+		
+		// Offset the raw value (-32768 to 32767) to be 0 to 65535
+		int normalizedX = currentPaddleRawValue + 32768;
+
+		joysticks->UpdatePaddleFromCursorPos(0, normalizedX, virtualWidth);
+} 
 else {
     if(SDL_GetRelativeMouseMode()) SDL_SetRelativeMouseMode(SDL_FALSE);
 }
@@ -1378,7 +1402,7 @@ else {
 					SDL_SetRelativeMouseMode(SDL_FALSE);
 				} 
 				else if (e.window.event == SDL_WINDOWEVENT_FOCUS_GAINED) {
-					if (paddle_emulation_enabled && !paddle_touch_mode) {
+					if (mouse_paddle_enabled && !paddle_touch_mode) {
 						SDL_SetRelativeMouseMode(SDL_TRUE);
 					}
 				}
@@ -1439,7 +1463,34 @@ else {
 						}
 					}
 				}
-            } else {
+            }
+#ifndef WASM_BUILD
+			else if (e.type == SDL_JOYAXISMOTION) {
+				if (paddleDetected && e.jaxis.axis == 0) {
+					if ( e.jaxis.which == paddle_instanceID) {
+						currentPaddleRawValue = e.jaxis.value;
+					}               
+				}
+            } else if (e.type == SDL_JOYBUTTONDOWN || e.type == SDL_JOYBUTTONUP) {
+                if (paddleDetected && e.jbutton.button == 0) {
+
+					bool isDown = (e.type == SDL_JOYBUTTONDOWN);
+					
+					joysticks->SetPaddleAButtonDirect(isDown);
+
+                }
+			 } else if (e.type == SDL_JOYDEVICEREMOVED) {
+				if (paddleDetected && e.jdevice.which == paddle_instanceID) {
+					paddleDetected = false;
+					paddle_instanceID = -1; // Reset it
+					printf("Paddle/JoyStick Disconnected\n");
+				}
+				PaddleInit();
+			} else if (e.type == SDL_JOYDEVICEADDED) {
+				PaddleInit();
+            } 
+#endif
+			 else {
 				joysticks->update(&e, showMenu || resetQueued);
 			}
         }
@@ -1502,6 +1553,7 @@ else {
 		joysticks->SetHeldButtons(0);//clear paddle bits before reset
 		joysticks->Reset();
 		resetQueued = 0;
+		currentPaddleRawValue = 0;
 	}
 	return running;
 }
@@ -1621,6 +1673,7 @@ int main(int argC, char* argV[]) {
 
 	emscripten_request_animation_frame_loop(mainloop, 0);
 #else
+	PaddleInit();
 	SDL_RaiseWindow(mainWindow);
 	while(running) {
 		mainloop(0, NULL);

--- a/src/gte.cpp
+++ b/src/gte.cpp
@@ -1226,10 +1226,8 @@ else if (joystick_paddle_enabled) {
 		// We treat the full joystick range as our "Window Width"
 		// Logical range of SDL Axis is 65535 units wide
 		const int virtualWidth = 65535;
-		
 		// Offset the raw value (-32768 to 32767) to be 0 to 65535
 		int normalizedX = currentPaddleRawValue + 32768;
-
 		joysticks->UpdatePaddleFromCursorPos(0, normalizedX, virtualWidth);
 } 
 else {
@@ -1473,11 +1471,8 @@ else {
 				}
             } else if (e.type == SDL_JOYBUTTONDOWN || e.type == SDL_JOYBUTTONUP) {
                 if (paddleDetected && e.jbutton.button == 0) {
-
 					bool isDown = (e.type == SDL_JOYBUTTONDOWN);
-					
 					joysticks->SetPaddleAButtonDirect(isDown);
-
                 }
 			 } else if (e.type == SDL_JOYDEVICEREMOVED) {
 				if (paddleDetected && e.jdevice.which == paddle_instanceID) {

--- a/src/paddle.cpp
+++ b/src/paddle.cpp
@@ -58,10 +58,3 @@ void PaddleInit(void) {
         }
     }
 }
-
-void PaddleCleanup(void) {
-    if (active_paddle_handle != NULL) {
-        SDL_JoystickClose(active_paddle_handle);
-        active_paddle_handle = NULL;
-    }
-}

--- a/src/paddle.cpp
+++ b/src/paddle.cpp
@@ -1,0 +1,67 @@
+#include "paddle.h"
+#include <stdio.h>
+
+bool joystick_paddle_enabled = false;
+bool paddleDetected = false;
+
+SDL_JoystickID paddle_instanceID = -1;
+int32_t currentPaddleRawValue = 0;
+static SDL_Joystick* active_paddle_handle = NULL;
+
+void PaddleInit(void) {
+    int num_joysticks = SDL_NumJoysticks();
+    SDL_JoystickID bakInstanceID = -1;
+
+    if (active_paddle_handle != NULL) {
+        bakInstanceID = paddle_instanceID;
+    }
+
+    paddleDetected = false; 
+    paddle_instanceID = -1;
+    
+    SDL_Joystick* chosen_joystick = NULL;
+    const char* chosen_name = NULL;
+
+    for (int i = 0; i < num_joysticks; i++) {
+        const char* name = SDL_JoystickNameForIndex(i);
+        SDL_Joystick* j = SDL_JoystickOpen(i); 
+        if (!j) continue;
+
+        if (chosen_joystick == NULL) {
+            chosen_joystick = j;
+            chosen_name = name;
+            break; 
+        }
+
+        if (j != chosen_joystick) {
+            SDL_JoystickClose(j);
+        }
+    }
+
+    if (chosen_joystick != NULL) {
+        if (active_paddle_handle != NULL && active_paddle_handle != chosen_joystick) {
+            SDL_JoystickClose(active_paddle_handle);
+        }
+
+        active_paddle_handle = chosen_joystick;
+        paddle_instanceID = SDL_JoystickInstanceID(active_paddle_handle);
+        paddleDetected = true;
+
+        if (paddle_instanceID != bakInstanceID) {
+            printf("Hardware Verified: %s (Instance ID: %d)\n", 
+                   chosen_name ? chosen_name : "Unknown", paddle_instanceID);
+        }
+    } else {
+        if (active_paddle_handle != NULL) {
+            SDL_JoystickClose(active_paddle_handle);
+            active_paddle_handle = NULL;
+        }
+    }
+}
+
+void PaddleCleanup(void) {
+    if (active_paddle_handle != NULL) {
+        SDL_JoystickClose(active_paddle_handle);
+        active_paddle_handle = NULL;
+    }
+}

--- a/src/paddle.h
+++ b/src/paddle.h
@@ -1,0 +1,18 @@
+#ifndef PADDLE_H
+#define PADDLE_H
+
+#include "SDL_inc.h"
+#include <stdbool.h>
+#include <stdint.h>
+
+// Configuration & State Flags
+extern bool joystick_paddle_enabled;
+extern bool paddleDetected;
+extern SDL_JoystickID paddle_instanceID;
+extern int32_t currentPaddleRawValue;
+
+// Function Declarations
+void PaddleInit(void);
+void PaddleCleanup(void);
+
+#endif // PADDLE_H

--- a/src/paddle.h
+++ b/src/paddle.h
@@ -5,14 +5,11 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-// Configuration & State Flags
 extern bool joystick_paddle_enabled;
 extern bool paddleDetected;
 extern SDL_JoystickID paddle_instanceID;
 extern int32_t currentPaddleRawValue;
 
-// Function Declarations
 void PaddleInit(void);
-void PaddleCleanup(void);
 
 #endif // PADDLE_H


### PR DESCRIPTION
This PR adds gametank paddle controls by utilizing joystick axis 0 on any joystick device connected. If multiple joysticks are connected it seems to choose the most recent one.

Note: This does not add joystick paddle support to the wasm build at this time

New menu options:
<img width="741" height="319" alt="Screenshot 2026-09-11 at 6 09 51 PM" src="https://github.com/user-attachments/assets/61ae7032-5d32-4d7a-bf96-cf34baa76816" />

Desktop build video demonstrates the robustness of this feature by connecting and disconnecting a custom usb paddle controller and ps4 controller. The debug text at the bottom shows what is connected/disconnected:

https://github.com/user-attachments/assets/8bd71e69-5c32-492c-b81f-63b5cc9214ac

Demo of Wrapper build showing these updates:

https://github.com/user-attachments/assets/c89d8f46-d21a-4340-a587-01de03407a5f

Did not record a WASM build because it is not affected by these updates